### PR TITLE
feat: Add support for pinned certificate fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+- Add support for certificate fingerprints
+
 ## 0.7.0
 
 - ADBC bulk ingestion support (create, append, replace, create-append modes) via `IngestTargetTable` and `IngestMode` statement options

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]

--- a/docs/setup-and-connect.md
+++ b/docs/setup-and-connect.md
@@ -64,6 +64,7 @@ All parameters are set via URL query string (`?key=value&key2=value2`).
 |---|---|---|---|
 | `tls` | `ssl`, `use_tls` | `false` | Enable TLS/SSL encryption |
 | `validate_certificate` | `verify_certificate`, `validateservercertificate` | `true` | Validate the server's TLS certificate |
+| `certificate_fingerprint` | `certificatefingerprint` | — | Pin connection to a specific server certificate (SHA-256 hex of DER cert) |
 | `connection_timeout` | `timeout` | `30` | Connection timeout in seconds (max 300) |
 | `query_timeout` | — | `300` | Query timeout in seconds |
 | `idle_timeout` | — | `600` | Idle connection timeout in seconds |

--- a/specs/connection-management/auth-and-security/spec.md
+++ b/specs/connection-management/auth-and-security/spec.md
@@ -14,6 +14,7 @@ Connection parameters are required for Exasol connectivity and SHALL be validate
 * *WHEN* a connection string is provided in the format `exasol://host:port`
 * *THEN* it SHALL parse host and port correctly
 * *AND* it SHALL support optional parameters (schema, encryption settings)
+* *AND* it SHALL parse `certificate_fingerprint` (alias `certificatefingerprint`) as the expected server certificate fingerprint
 
 ### Scenario: Parameter validation
 
@@ -29,6 +30,7 @@ Connection parameters are required for Exasol connectivity and SHALL be validate
 * *WHEN* TLS/SSL is requested
 * *THEN* it SHALL support enabling encrypted connections
 * *AND* it SHALL validate certificate settings if certificate validation is enabled
+* *AND* it SHALL accept an optional certificate fingerprint for pin-based validation
 
 ### Scenario: Username and password authentication
 
@@ -65,3 +67,27 @@ Connection parameters are required for Exasol connectivity and SHALL be validate
 * *WHEN* logging connection events
 * *THEN* it SHALL NOT log passwords or sensitive authentication tokens
 * *AND* it SHALL redact credentials from error messages
+
+### Scenario: Certificate fingerprint validation success
+
+* *GIVEN* a TLS connection is being established
+* *AND* `certificate_fingerprint` is set to the SHA-256 hex fingerprint of the server's certificate
+* *WHEN* the TLS handshake completes
+* *THEN* the driver SHALL compute the SHA-256 hex digest of the server's DER-encoded certificate
+* *AND* it SHALL accept the connection when the fingerprints match
+
+### Scenario: Certificate fingerprint validation failure
+
+* *GIVEN* a TLS connection is being established
+* *AND* `certificate_fingerprint` is set to an incorrect value
+* *WHEN* the TLS handshake completes
+* *THEN* the driver SHALL reject the connection with a certificate fingerprint mismatch error
+* *AND* the error MUST include both the expected fingerprint and the actual server fingerprint
+
+### Scenario: Certificate fingerprint bypasses hostname validation
+
+* *GIVEN* a TLS connection is being established
+* *AND* `certificate_fingerprint` is set
+* *WHEN* the TLS handshake completes
+* *THEN* the driver SHALL skip standard certificate chain and hostname validation
+* *AND* it SHALL rely solely on the fingerprint match for trust

--- a/src/adbc/connection.rs
+++ b/src/adbc/connection.rs
@@ -92,10 +92,13 @@ impl Connection {
         let mut transport = WebSocketTransport::new();
 
         // Convert ConnectionParams to TransportConnectionParams
-        let transport_params = TransportConnectionParams::new(params.host.clone(), params.port)
+        let mut transport_params = TransportConnectionParams::new(params.host.clone(), params.port)
             .with_tls(params.use_tls)
             .with_validate_server_certificate(params.validate_server_certificate)
             .with_timeout(params.connection_timeout.as_millis() as u64);
+        if let Some(ref fp) = params.certificate_fingerprint {
+            transport_params = transport_params.with_certificate_fingerprint(fp.clone());
+        }
 
         // Connect
         transport.connect(&transport_params).await.map_err(|e| {

--- a/src/connection/params.rs
+++ b/src/connection/params.rs
@@ -42,6 +42,9 @@ pub struct ConnectionParams {
     /// TLS certificate validation mode
     pub validate_server_certificate: bool,
 
+    /// Expected SHA-256 hex fingerprint of the server's DER certificate
+    pub certificate_fingerprint: Option<String>,
+
     /// Client name for session identification
     pub client_name: String,
 
@@ -171,6 +174,7 @@ impl fmt::Debug for ConnectionParams {
                 "validate_server_certificate",
                 &self.validate_server_certificate,
             )
+            .field("certificate_fingerprint", &self.certificate_fingerprint)
             .field("client_name", &self.client_name)
             .field("client_version", &self.client_version)
             .field("attributes", &self.attributes)
@@ -201,6 +205,7 @@ pub struct ConnectionBuilder {
     idle_timeout: Option<Duration>,
     use_tls: Option<bool>,
     validate_server_certificate: Option<bool>,
+    certificate_fingerprint: Option<String>,
     client_name: Option<String>,
     client_version: Option<String>,
     attributes: HashMap<String, String>,
@@ -220,6 +225,7 @@ impl ConnectionBuilder {
             idle_timeout: None,
             use_tls: None,
             validate_server_certificate: None,
+            certificate_fingerprint: None,
             client_name: None,
             client_version: None,
             attributes: HashMap::new(),
@@ -283,6 +289,12 @@ impl ConnectionBuilder {
     /// Enable or disable server certificate validation.
     pub fn validate_server_certificate(mut self, validate: bool) -> Self {
         self.validate_server_certificate = Some(validate);
+        self
+    }
+
+    /// Pin TLS connection to a specific certificate fingerprint (SHA-256 hex of DER cert).
+    pub fn certificate_fingerprint(mut self, fingerprint: &str) -> Self {
+        self.certificate_fingerprint = Some(fingerprint.to_string());
         self
     }
 
@@ -368,6 +380,7 @@ impl ConnectionBuilder {
             idle_timeout,
             use_tls: self.use_tls.unwrap_or(false),
             validate_server_certificate: self.validate_server_certificate.unwrap_or(true),
+            certificate_fingerprint: self.certificate_fingerprint,
             client_name: self.client_name.unwrap_or_else(|| "exarrow-rs".to_string()),
             client_version: self
                 .client_version
@@ -524,6 +537,9 @@ fn apply_query_params(
             }
             "client_version" => {
                 builder = builder.client_version(&value);
+            }
+            "certificate_fingerprint" | "certificatefingerprint" => {
+                builder = builder.certificate_fingerprint(&value);
             }
             _ => {
                 // Store as custom attribute
@@ -1203,5 +1219,21 @@ mod tests {
 
         assert_eq!(params.host, "localhost");
         assert_eq!(params.username, "user");
+    }
+
+    #[test]
+    fn test_parse_certificate_fingerprint_param() {
+        let params = "exasol://user:pass@localhost?tls=true&certificate_fingerprint=aabbcc"
+            .parse::<ConnectionParams>()
+            .unwrap();
+        assert_eq!(params.certificate_fingerprint.as_deref(), Some("aabbcc"));
+    }
+
+    #[test]
+    fn test_parse_certificatefingerprint_alias() {
+        let params = "exasol://user:pass@localhost?tls=true&certificatefingerprint=ddeeff"
+            .parse::<ConnectionParams>()
+            .unwrap();
+        assert_eq!(params.certificate_fingerprint.as_deref(), Some("ddeeff"));
     }
 }

--- a/src/transport/protocol.rs
+++ b/src/transport/protocol.rs
@@ -20,6 +20,8 @@ pub struct ConnectionParams {
     pub use_tls: bool,
     /// Validate server certificate (default: true)
     pub validate_server_certificate: bool,
+    /// Expected SHA-256 hex fingerprint of the server's DER certificate
+    pub certificate_fingerprint: Option<String>,
     /// Connection timeout in milliseconds
     pub timeout_ms: u64,
 }
@@ -32,6 +34,7 @@ impl ConnectionParams {
             port,
             use_tls: true,
             validate_server_certificate: true,
+            certificate_fingerprint: None,
             timeout_ms: 30_000, // 30 seconds default
         }
     }
@@ -51,6 +54,12 @@ impl ConnectionParams {
     /// with self-signed certificates.
     pub fn with_validate_server_certificate(mut self, validate: bool) -> Self {
         self.validate_server_certificate = validate;
+        self
+    }
+
+    /// Pin TLS connection to a specific certificate fingerprint (SHA-256 hex of DER cert).
+    pub fn with_certificate_fingerprint(mut self, fingerprint: String) -> Self {
+        self.certificate_fingerprint = Some(fingerprint);
         self
     }
 
@@ -83,11 +92,8 @@ impl Credentials {
     }
 }
 
-// Security: Implement Drop to clear password from memory
 impl Drop for Credentials {
     fn drop(&mut self) {
-        // Clear password bytes (basic security measure)
-        // For production, consider using the `zeroize` crate
         self.password.clear();
     }
 }

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -299,7 +299,15 @@ impl TransportProtocol for WebSocketTransport {
 
         // Create TLS connector if needed
         let connector = if params.use_tls {
-            let tls_connector = if params.validate_server_certificate {
+            let tls_connector = if let Some(ref fingerprint) = params.certificate_fingerprint {
+                let config = rustls::ClientConfig::builder()
+                    .dangerous()
+                    .with_custom_certificate_verifier(Arc::new(FingerprintVerifier {
+                        expected_fingerprint: fingerprint.clone(),
+                    }))
+                    .with_no_client_auth();
+                Connector::Rustls(Arc::new(config))
+            } else if params.validate_server_certificate {
                 // Use default rustls config with native root certificates
                 let mut root_store = rustls::RootCertStore::empty();
                 let certs = rustls_native_certs::load_native_certs();
@@ -312,7 +320,6 @@ impl TransportProtocol for WebSocketTransport {
                     .with_no_client_auth();
                 Connector::Rustls(Arc::new(config))
             } else {
-                // Disable certificate verification (danger!)
                 let config = rustls::ClientConfig::builder()
                     .dangerous()
                     .with_custom_certificate_verifier(Arc::new(NoVerifier))
@@ -759,6 +766,22 @@ impl TransportProtocol for WebSocketTransport {
     }
 }
 
+/// Returns the set of signature schemes supported by the custom certificate verifiers.
+fn all_supported_verify_schemes() -> Vec<rustls::SignatureScheme> {
+    vec![
+        rustls::SignatureScheme::RSA_PKCS1_SHA256,
+        rustls::SignatureScheme::RSA_PKCS1_SHA384,
+        rustls::SignatureScheme::RSA_PKCS1_SHA512,
+        rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+        rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+        rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+        rustls::SignatureScheme::RSA_PSS_SHA256,
+        rustls::SignatureScheme::RSA_PSS_SHA384,
+        rustls::SignatureScheme::RSA_PSS_SHA512,
+        rustls::SignatureScheme::ED25519,
+    ]
+}
+
 /// A certificate verifier that accepts any certificate.
 /// Used when certificate validation is disabled.
 #[derive(Debug)]
@@ -795,18 +818,63 @@ impl rustls::client::danger::ServerCertVerifier for NoVerifier {
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        vec![
-            rustls::SignatureScheme::RSA_PKCS1_SHA256,
-            rustls::SignatureScheme::RSA_PKCS1_SHA384,
-            rustls::SignatureScheme::RSA_PKCS1_SHA512,
-            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
-            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
-            rustls::SignatureScheme::RSA_PSS_SHA256,
-            rustls::SignatureScheme::RSA_PSS_SHA384,
-            rustls::SignatureScheme::RSA_PSS_SHA512,
-            rustls::SignatureScheme::ED25519,
-        ]
+        all_supported_verify_schemes()
+    }
+}
+
+/// A certificate verifier that validates by SHA-256 fingerprint of the DER-encoded certificate.
+/// Bypasses hostname and CA chain validation.
+#[derive(Debug)]
+struct FingerprintVerifier {
+    expected_fingerprint: String,
+}
+
+impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        use aws_lc_rs::digest;
+        let fingerprint = digest::digest(&digest::SHA256, end_entity.as_ref());
+        let actual: String = fingerprint
+            .as_ref()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect();
+        if actual == self.expected_fingerprint {
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        } else {
+            Err(rustls::Error::General(format!(
+                "Certificate fingerprint mismatch: expected {}, got {}",
+                self.expected_fingerprint, actual
+            )))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        all_supported_verify_schemes()
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1989,3 +1989,102 @@ async fn test_large_result_set_exceeds_default_frame_limit() {
     cleanup_schema(&mut conn, &schema_name).await;
     conn.close().await.expect("Failed to close connection");
 }
+
+// Section: Certificate Fingerprint Tests
+
+/// Connects with a wrong fingerprint and verifies the error contains the actual SHA-256 hex
+/// fingerprint (64 hex chars).
+#[tokio::test]
+async fn test_connect_with_wrong_fingerprint_fails() {
+    skip_if_no_exasol!();
+
+    let conn_str = format!(
+        "exasol://{}:{}@{}:{}?tls=true&certificate_fingerprint=0000000000000000000000000000000000000000000000000000000000000000",
+        common::get_user(),
+        common::get_password(),
+        common::get_host(),
+        common::get_port(),
+    );
+
+    let driver = exarrow_rs::adbc::Driver::new();
+    let database = driver.open(&conn_str).expect("open should succeed");
+    let result = database.connect().await;
+
+    assert!(
+        result.is_err(),
+        "Connection with wrong fingerprint should fail"
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+    // The error message should contain the actual 64-char SHA-256 hex fingerprint
+    let hex_chars: String = err_msg.chars().filter(|c| c.is_ascii_hexdigit()).collect();
+    assert!(
+        hex_chars.len() >= 64,
+        "Error message should contain a 64-char SHA-256 hex fingerprint, got: {}",
+        err_msg
+    );
+}
+
+/// Connects with a placeholder fingerprint to discover the actual fingerprint, then reconnects
+/// using the actual fingerprint to verify successful pinned connection.
+#[tokio::test]
+async fn test_connect_with_certificate_fingerprint() {
+    skip_if_no_exasol!();
+
+    // Step 1: Connect with a wrong fingerprint to discover the actual fingerprint
+    let conn_str_wrong = format!(
+        "exasol://{}:{}@{}:{}?tls=true&certificate_fingerprint=placeholder",
+        common::get_user(),
+        common::get_password(),
+        common::get_host(),
+        common::get_port(),
+    );
+
+    let driver = exarrow_rs::adbc::Driver::new();
+    let database = driver.open(&conn_str_wrong).expect("open should succeed");
+    let result = database.connect().await;
+
+    assert!(
+        result.is_err(),
+        "Connection with placeholder fingerprint should fail"
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+
+    // Extract the actual fingerprint from the error message ("got <fingerprint>")
+    let actual_fingerprint = err_msg
+        .split("got ")
+        .nth(1)
+        .map(|s| s.trim().to_string())
+        .expect("Error message should contain 'got <fingerprint>'");
+
+    assert_eq!(
+        actual_fingerprint.len(),
+        64,
+        "Actual fingerprint should be 64 hex chars, got: '{}'",
+        actual_fingerprint
+    );
+
+    // Step 2: Reconnect using the discovered fingerprint — should succeed
+    let conn_str_pinned = format!(
+        "exasol://{}:{}@{}:{}?tls=true&certificate_fingerprint={}",
+        common::get_user(),
+        common::get_password(),
+        common::get_host(),
+        common::get_port(),
+        actual_fingerprint,
+    );
+
+    let database2 = driver.open(&conn_str_pinned).expect("open should succeed");
+    let conn = database2
+        .connect()
+        .await
+        .expect("Connection with correct fingerprint should succeed");
+
+    assert!(
+        !conn.is_closed().await,
+        "Connection should be open after fingerprint-pinned connect"
+    );
+
+    conn.close().await.expect("Failed to close connection");
+}


### PR DESCRIPTION
## Summary

- Add `certificate_fingerprint` DSN query parameter (alias: `certificatefingerprint`) for TLS certificate pinning
- Implement `FingerprintVerifier`: a custom `rustls::ServerCertVerifier` that computes SHA-256 of the server's DER-encoded certificate and accepts the connection only on match
- TLS connector priority: fingerprint pin → native root CA validation → no verification (`NoVerifier`)
- Fingerprint bypasses hostname and CA chain validation — useful for self-signed certificates without disabling TLS entirely
- On mismatch, the error includes both expected and actual fingerprints to aid initial setup bootstrapping
- Matches Go driver parity (`certificatefingerprint` alias accepted)

## Usage

exasol://user:pass@host:8563?tls=true&certificate_fingerprint=<sha256-hex>