### PR TITLE
fix: support RSA keys smaller than 2048 bits for authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +944,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -1049,7 +1073,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -1073,6 +1097,7 @@ dependencies = [
  "polars",
  "rand 0.8.5",
  "rcgen",
+ "rsa",
  "rustls",
  "rustls-native-certs",
  "serde",
@@ -1508,6 +1533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1772,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1808,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1889,6 +1950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +1987,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2743,6 +2834,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,6 +3065,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,6 +3144,22 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ dotenvy = { version = "0.15", optional = true }
 
 # Polars for DataFrame benchmarks (optional)
 polars = { version = "0.46", features = ["lazy", "ipc_streaming", "dtype-decimal"], optional = true }
+rsa = "0.9.10"
 
 [dev-dependencies]
 # Mocking for tests

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -6,7 +6,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use aws_lc_rs::rsa::{Pkcs1PublicEncryptingKey, PublicEncryptingKey};
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
@@ -150,133 +149,27 @@ impl WebSocketTransport {
     ///
     /// The password is encrypted using the server's public key and then
     /// base64-encoded for transmission.
+    ///
+    /// Uses the `rsa` crate which supports all RSA key sizes. Exasol servers may
+    /// send 1024-bit, 2048-bit, or larger RSA public keys depending on the server
+    /// version and configuration.
     fn encrypt_password(password: &str, public_key_pem: &str) -> Result<String, TransportError> {
-        // Parse PEM to DER (strip headers and base64-decode)
-        let der_bytes = Self::pem_to_der(public_key_pem).map_err(|e| {
-            TransportError::ProtocolError(format!("Failed to parse RSA public key PEM: {}", e))
-        })?;
+        use rsa::pkcs1::DecodeRsaPublicKey;
+        use rsa::rand_core::OsRng;
+        use rsa::{Pkcs1v15Encrypt, RsaPublicKey};
 
-        // Load RSA public key from DER
-        let public_key = PublicEncryptingKey::from_der(&der_bytes).map_err(|e| {
+        let public_key = RsaPublicKey::from_pkcs1_pem(public_key_pem).map_err(|e| {
             TransportError::ProtocolError(format!("Failed to parse RSA public key: {}", e))
         })?;
 
-        // Create PKCS#1 v1.5 encryptor
-        let pkcs1_key = Pkcs1PublicEncryptingKey::new(public_key).map_err(|e| {
-            TransportError::ProtocolError(format!("Failed to create PKCS1 key: {}", e))
-        })?;
-
-        // Encrypt the password
-        let mut ciphertext = vec![0u8; pkcs1_key.ciphertext_size()];
-        let ciphertext = pkcs1_key
-            .encrypt(password.as_bytes(), &mut ciphertext)
+        let mut rng = OsRng;
+        let ciphertext = public_key
+            .encrypt(&mut rng, Pkcs1v15Encrypt, password.as_bytes())
             .map_err(|e| {
                 TransportError::ProtocolError(format!("Failed to encrypt password: {}", e))
             })?;
 
-        // Base64-encode the encrypted password
         Ok(STANDARD.encode(ciphertext))
-    }
-
-    /// Convert PKCS#1 PEM to SPKI DER format.
-    ///
-    /// Exasol sends RSA public keys in PKCS#1 PEM format (`BEGIN RSA PUBLIC KEY`).
-    /// aws-lc-rs expects SPKI (SubjectPublicKeyInfo) DER format, so we:
-    /// 1. Strip PEM headers and base64-decode to get PKCS#1 DER
-    /// 2. Wrap the PKCS#1 DER in SPKI structure
-    fn pem_to_der(pem: &str) -> Result<Vec<u8>, &'static str> {
-        // Find the base64 content between PEM headers
-        let start_marker = "-----BEGIN RSA PUBLIC KEY-----";
-        let end_marker = "-----END RSA PUBLIC KEY-----";
-
-        let start = pem.find(start_marker).ok_or("Missing PEM start marker")? + start_marker.len();
-        let end = pem.find(end_marker).ok_or("Missing PEM end marker")?;
-
-        // Extract and decode base64 content to get PKCS#1 DER
-        let base64_content: String = pem[start..end]
-            .chars()
-            .filter(|c| !c.is_whitespace())
-            .collect();
-
-        let pkcs1_der = STANDARD
-            .decode(&base64_content)
-            .map_err(|_| "Invalid base64 in PEM")?;
-
-        // Convert PKCS#1 DER to SPKI DER
-        Ok(Self::pkcs1_to_spki(&pkcs1_der))
-    }
-
-    /// Convert PKCS#1 RSAPublicKey DER to SPKI SubjectPublicKeyInfo DER.
-    ///
-    /// SPKI format wraps the PKCS#1 key with an algorithm identifier:
-    /// ```asn1
-    /// SubjectPublicKeyInfo ::= SEQUENCE {
-    ///   algorithm AlgorithmIdentifier,
-    ///   subjectPublicKey BIT STRING
-    /// }
-    /// AlgorithmIdentifier ::= SEQUENCE {
-    ///   algorithm OBJECT IDENTIFIER,  -- 1.2.840.113549.1.1.1 (rsaEncryption)
-    ///   parameters ANY DEFINED BY algorithm OPTIONAL  -- NULL for RSA
-    /// }
-    /// ```
-    fn pkcs1_to_spki(pkcs1_der: &[u8]) -> Vec<u8> {
-        // RSA algorithm identifier: SEQUENCE { OID 1.2.840.113549.1.1.1, NULL }
-        // OID 1.2.840.113549.1.1.1 (rsaEncryption) encoded as:
-        // 06 09 2A 86 48 86 F7 0D 01 01 01 (OID tag, length, value)
-        // 05 00 (NULL tag, zero length)
-        let algorithm_identifier: &[u8] = &[
-            0x30, 0x0D, // SEQUENCE, length 13
-            0x06, 0x09, // OID, length 9
-            0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01, // 1.2.840.113549.1.1.1
-            0x05, 0x00, // NULL
-        ];
-
-        // BIT STRING header: tag (0x03) + length + unused bits (0x00)
-        // The bit string contains the PKCS#1 key prefixed with 0x00 (no unused bits)
-        let bit_string_content_len = pkcs1_der.len() + 1; // +1 for the unused bits byte
-
-        // Calculate lengths for DER encoding
-        let bit_string_len = Self::der_length_bytes(bit_string_content_len);
-        let total_content_len =
-            algorithm_identifier.len() + 1 + bit_string_len.len() + bit_string_content_len;
-        let sequence_len = Self::der_length_bytes(total_content_len);
-
-        // Build SPKI DER
-        let mut spki = Vec::with_capacity(1 + sequence_len.len() + total_content_len);
-
-        // Outer SEQUENCE
-        spki.push(0x30); // SEQUENCE tag
-        spki.extend_from_slice(&sequence_len);
-
-        // Algorithm identifier
-        spki.extend_from_slice(algorithm_identifier);
-
-        // BIT STRING containing PKCS#1 key
-        spki.push(0x03); // BIT STRING tag
-        spki.extend_from_slice(&bit_string_len);
-        spki.push(0x00); // No unused bits
-        spki.extend_from_slice(pkcs1_der);
-
-        spki
-    }
-
-    /// Encode a length value in DER format.
-    fn der_length_bytes(len: usize) -> Vec<u8> {
-        if len < 128 {
-            vec![len as u8]
-        } else if len < 256 {
-            vec![0x81, len as u8]
-        } else if len < 65536 {
-            vec![0x82, (len >> 8) as u8, (len & 0xFF) as u8]
-        } else {
-            // For very large lengths (unlikely for RSA keys)
-            vec![
-                0x83,
-                (len >> 16) as u8,
-                ((len >> 8) & 0xFF) as u8,
-                (len & 0xFF) as u8,
-            ]
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace `aws_lc_rs` RSA encryption with the `rsa` crate for password encryption during Exasol authentication
- Fixes authentication failure against servers that send 1024-bit RSA public keys

## Problem

`aws_lc_rs::rsa::PublicEncryptingKey::from_der()` enforces a minimum 2048-bit key size (hardcoded `2048..=8192` range in `encryption.rs`). Many Exasol servers — including the Exasol Showcase Cluster (`demodb.exasol.com`) — send 1024-bit RSA public keys during the login handshake.

This causes every connection attempt to fail with:

```
Authentication failed: Protocol error: Failed to parse RSA public key: Unspecified
```

## Fix

Replace the `aws_lc_rs` RSA encryption path with the `rsa` crate, which supports all standard RSA key sizes. The `rsa` crate's `RsaPublicKey::from_pkcs1_pem()` parses PEM directly, which also eliminates the manual PKCS#1→SPKI DER conversion (`pem_to_der`, `pkcs1_to_spki`, `der_length_bytes` helpers — ~80 lines removed).

### Before
```rust
use aws_lc_rs::rsa::{Pkcs1PublicEncryptingKey, PublicEncryptingKey};

let der_bytes = Self::pem_to_der(public_key_pem)?;           // manual PEM→DER
let spki_der = Self::pkcs1_to_spki(&der_bytes);              // manual PKCS#1→SPKI  
let public_key = PublicEncryptingKey::from_der(&spki_der)?;   // ❌ rejects <2048-bit
let pkcs1_key = Pkcs1PublicEncryptingKey::new(public_key)?;
pkcs1_key.encrypt(password.as_bytes(), &mut ciphertext)?;
```

### After
```rust
use rsa::pkcs1::DecodeRsaPublicKey;
use rsa::{Pkcs1v15Encrypt, RsaPublicKey};

let public_key = RsaPublicKey::from_pkcs1_pem(pem)?;         // ✅ accepts all sizes
let ciphertext = public_key.encrypt(&mut OsRng, Pkcs1v15Encrypt, password.as_bytes())?;
```

## Test plan

- [x] All 48 existing unit tests pass
- [x] Tested against Exasol Showcase Cluster (1024-bit RSA key, `demodb.exasol.com:8563`) — connection and query execution work
- [x] Tested TPC-H Q1 query against `TPCH_10GB` schema — returns correct results
- [x] `cargo build` compiles cleanly
- [x] 2048-bit key test (`test_encrypt_password_with_valid_key`) still passes