### PR TITLE
fix(security): patch 4 Dependabot advisories (0.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.3
+
+- Security: update vulnerable transitive dependencies to address 4 Dependabot advisories.
+  - `lz4_flex` 0.12.0 → 0.12.1 (GHSA-vvp9-7p8x-rfvv, high — decompression may leak uninitialized memory).
+  - `aws-lc-sys` 0.38.0 → 0.39.1 via `aws-lc-rs` 1.16.1 → 1.16.2 (GHSA-394x-vwmw-crm3 high — X.509 Name Constraints bypass; GHSA-9f94-5g5w-gf6r high — CRL Distribution Point scope check logic error).
+  - `rustls-webpki` 0.103.9 → 0.103.11 (GHSA-pwjx-qhcg-rvj4, medium — CRL Distribution Point authority matching).
+
 ## 0.7.2
 
 - Support RSA 1024-bit public keys during the Exasol login handshake (e.g. `demodb.exasol.com`). Previously failed with `Failed to parse RSA public key` because aws-lc-rs enforces a 2048-bit minimum; the driver now uses an in-tree PKCS#1 v1.5 encryption path covering 1024–8192 bit moduli.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,9 +461,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -1049,7 +1049,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -1641,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 dependencies = [
  "twox-hash",
 ]
@@ -2802,9 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]


### PR DESCRIPTION
## Summary

Updates transitive dependencies to close all 4 open Dependabot alerts on the repository. No changes to the crate's direct-dependency declarations — only \`Cargo.lock\`.

| Severity | Package | From → To | Advisory |
|---|---|---|---|
| high | \`lz4_flex\` | 0.12.0 → 0.12.1 | [GHSA-vvp9-7p8x-rfvv](https://github.com/advisories/GHSA-vvp9-7p8x-rfvv) — decompression may leak uninitialized memory |
| high | \`aws-lc-sys\` | 0.38.0 → 0.39.1 | [GHSA-394x-vwmw-crm3](https://github.com/advisories/GHSA-394x-vwmw-crm3) — X.509 Name Constraints bypass via wildcard/Unicode CN |
| high | \`aws-lc-sys\` | 0.38.0 → 0.39.1 | [GHSA-9f94-5g5w-gf6r](https://github.com/advisories/GHSA-9f94-5g5w-gf6r) — CRL Distribution Point scope check logic error |
| medium | \`rustls-webpki\` | 0.103.9 → 0.103.11 | [GHSA-pwjx-qhcg-rvj4](https://github.com/advisories/GHSA-pwjx-qhcg-rvj4) — CRLs not considered authoritative by DP |

\`aws-lc-sys\` is constrained by its parent \`aws-lc-rs\`; bumping \`aws-lc-rs\` 1.16.1 → 1.16.2 pulls in the patched 0.39.1.

## Release

Bumps version to **0.7.3**; \`CHANGELOG.md\` updated. On merge, CI creates tag \`v0.7.3\`, the GitHub release, and publishes to crates.io automatically.

## Test plan

- [x] \`cargo test --lib\` → 911 passed
- [x] \`cargo test --test integration_tests\` → 48 passed (live Exasol Docker)
- [x] \`cargo test --test driver_manager_tests\` → 40 passed
- [x] \`cargo clippy --all-targets --all-features -- -W clippy::all\` → 0 warnings
- [x] \`cargo fmt --all -- --check\` → clean
- [x] \`cargo build --release --features ffi\` → exit 0