### PR TITLE
change: default tls=true to match Exasol server + official drivers (0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.0
+
+- **Breaking default change**: connections now default to `tls=true` to match the Exasol server 7.1+ requirement and every official Exasol driver (pyexasol, JDBC, Go, ODBC). Callers that relied on the previous `tls=false` default — e.g. to reach legacy (pre-7.1) Exasol servers — must set `?tls=false` explicitly on the connection string or `.use_tls(false)` on the builder.
+- **Docker recipe**: Exasol Docker containers ship with a self-signed certificate. Connection strings must set `?validateservercertificate=0` (alias `validate_certificate=false`) to accept it. Example: `exasol://sys:exasol@localhost:8563?validateservercertificate=0` — no `?tls=true` needed.
+- Certificate validation default (`validateservercertificate=true`) is unchanged and matches every official Exasol driver.
+
 ## 0.7.3
 
 - Security: update vulnerable transitive dependencies to address 4 Dependabot advisories.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ Specifications live in `specs/` using a `specs/<domain>/<feature>/spec.md` struc
 
 ## Important Constraints
 
-- TLS enabled by default; production Exasol requires it
+- TLS is enabled by default in both the public connection-string/builder API and the low-level transport struct, matching Exasol 7.1+ (which requires TLS on port 8563) and all official Exasol drivers (pyexasol, JDBC, Go, ODBC).
+- Certificate validation is on by default. Exasol Docker containers ship a self-signed certificate — test connection strings must set `?validateservercertificate=0` to accept it.
 - Never log or expose connection passwords
 - Integration tests require running Exasol instance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]

--- a/docs/setup-and-connect.md
+++ b/docs/setup-and-connect.md
@@ -16,7 +16,7 @@ exasol://[user[:password]@]host[:port][/schema][?params]
 exasol://localhost:8563
 exasol://user:password@localhost:8563
 exasol://user:password@exasol.example.com:8563/my_schema
-exasol://user:password@host:8563/schema?tls=false&connection_timeout=60
+exasol://user:password@host:8563/schema?connection_timeout=60
 ```
 
 ## Docker Quickstart
@@ -32,7 +32,7 @@ Default credentials: `sys` / `exasol`
 Recommended connection string for Docker:
 
 ```
-exasol://sys:exasol@localhost:8563?tls=true&validateservercertificate=0
+exasol://sys:exasol@localhost:8563?validateservercertificate=0
 ```
 
 > [!NOTE]
@@ -62,7 +62,7 @@ All parameters are set via URL query string (`?key=value&key2=value2`).
 
 | Parameter | Aliases | Default | Description |
 |---|---|---|---|
-| `tls` | `ssl`, `use_tls` | `false` | Enable TLS/SSL encryption |
+| `tls` | `ssl`, `use_tls` | `true` | Enable TLS/SSL encryption |
 | `validate_certificate` | `verify_certificate`, `validateservercertificate` | `true` | Validate the server's TLS certificate |
 | `certificate_fingerprint` | `certificatefingerprint` | — | Pin connection to a specific server certificate (SHA-256 hex of DER cert) |
 | `connection_timeout` | `timeout` | `30` | Connection timeout in seconds (max 300) |
@@ -116,16 +116,18 @@ The following attributes are read-only and cannot be set via the connection stri
 
 ## TLS Configuration
 
-TLS is **disabled** by default. For production environments, enable TLS and keep certificate validation on:
+TLS is **enabled** by default, matching Exasol 7.1+ (which requires TLS on port 8563) and all official Exasol drivers.
+
+**Docker / self-signed certificate** — disable certificate validation (TLS stays on):
 
 ```
-exasol://user:password@host:8563?tls=true
+exasol://user:password@host:8563?validateservercertificate=0
 ```
 
-For development with self-signed certificates, disable certificate validation:
+**Legacy pre-7.1 Exasol server** — disable TLS entirely:
 
 ```
-exasol://user:password@host:8563?tls=true&validateservercertificate=0
+exasol://user:password@host:8563?tls=false
 ```
 
 ## Timeouts

--- a/specs/connection-management/auth-and-security/spec.md
+++ b/specs/connection-management/auth-and-security/spec.md
@@ -28,8 +28,10 @@ Connection parameters are required for Exasol connectivity and SHALL be validate
 
 * *GIVEN* connection parameters are configured
 * *WHEN* TLS/SSL is requested
-* *THEN* it SHALL support enabling encrypted connections
-* *AND* it SHALL validate certificate settings if certificate validation is enabled
+* *THEN* it SHALL enable TLS by default when the `tls` parameter (aliases `ssl`, `use_tls`) is omitted from the connection string
+* *AND* it SHALL enable server-certificate validation by default when the `validate_certificate` parameter (aliases `verify_certificate`, `validateservercertificate`) is omitted
+* *AND* it SHALL honor an explicit `tls=false` to disable TLS for legacy (pre-7.1) Exasol servers
+* *AND* it SHALL honor an explicit `validateservercertificate=0` to disable certificate validation for self-signed certificates (e.g. Exasol Docker)
 * *AND* it SHALL accept an optional certificate fingerprint for pin-based validation
 
 ### Scenario: Username and password authentication

--- a/src/connection/params.rs
+++ b/src/connection/params.rs
@@ -378,7 +378,7 @@ impl ConnectionBuilder {
             connection_timeout,
             query_timeout,
             idle_timeout,
-            use_tls: self.use_tls.unwrap_or(false),
+            use_tls: self.use_tls.unwrap_or(true),
             validate_server_certificate: self.validate_server_certificate.unwrap_or(true),
             certificate_fingerprint: self.certificate_fingerprint,
             client_name: self.client_name.unwrap_or_else(|| "exarrow-rs".to_string()),
@@ -862,7 +862,7 @@ mod tests {
         assert_eq!(params.connection_timeout, Duration::from_secs(30));
         assert_eq!(params.query_timeout, Duration::from_secs(300));
         assert_eq!(params.idle_timeout, Duration::from_secs(600));
-        assert!(!params.use_tls);
+        assert!(params.use_tls);
         assert!(params.validate_server_certificate);
         assert_eq!(params.client_name, "exarrow-rs");
     }


### PR DESCRIPTION
## Summary

- **Breaking default change**: the public connection-string / \`ConnectionBuilder\` API now defaults \`tls\` to **\`true\`**, matching the Exasol 7.1+ server (which requires TLS on port 8563) and every official Exasol client driver — **pyexasol** (\`encryption=True\`), **JDBC** (\`validateservercertificate=1\`), **Go** (\`encryption=1\`, \`validateservercertificate=1\`), **ODBC** (\`SSL_VERIFY_SERVER\`).
- **What breaks**: callers that relied on the previous \`tls=false\` default — e.g. to reach legacy pre-7.1 Exasol servers — must set \`?tls=false\` (or \`.use_tls(false)\`) explicitly. Stock Exasol Docker containers use a self-signed cert, so those connection strings need \`?validateservercertificate=0\`.
- **What doesn't change**: \`validate_certificate\` default (already \`true\`), the low-level transport struct, the ADBC FFI surface (inherits the builder default automatically), the HTTP-tunnel \`CsvImportOptions\` / \`CsvExportOptions\` (left at \`false\` — separate code path, out of scope).

## Scope

6 files changed. Exactly one functional line flipped (\`src/connection/params.rs:381\`); everything else is test assertion, version bump, CHANGELOG, docs, and the spec delta.

## Release

Bumps version to **0.8.0** (minor — pre-1.0 idiomatic signal for a behavior-breaking default change). Merge triggers the existing release pipeline (tag \`v0.8.0\`, GitHub release, \`cargo publish\`).

## Test plan

- [x] \`cargo test --lib\` → 911 passed (\`test_builder_default_values\` assertion flipped to \`assert!(params.use_tls)\`; \`test_parse_bool_*\` unchanged — they set \`tls=no/off/0/false\` explicitly and still correctly assert \`!params.use_tls\`)
- [x] \`cargo test --test integration_tests\` → 48 passed (harness already uses \`?tls=true&validateservercertificate=0\` via \`tests/common/mod.rs:140\`)
- [x] \`cargo test --test driver_manager_tests\` → 40 passed
- [x] \`cargo clippy --all-targets --all-features -- -W clippy::all\` → 0 warnings
- [x] \`cargo fmt --all -- --check\` → clean
- [x] \`cargo build --release --features ffi\` → exit 0 (\`exarrow-rs v0.8.0\`)
- [x] **End-to-end proof**: a connection string with **no** \`?tls=…\` (just \`exasol://sys:exasol@localhost:8563?validateservercertificate=0\`) successfully connects under TLS against Docker Exasol and returns rows from \`SELECT 1+1\`.

## Spec

\`specs/connection-management/auth-and-security/spec.md\`: the "TLS configuration" scenario is updated to state the new defaults and list both explicit opt-out paths.

## Migration

| Old connection string | Works on 0.8.0? | Fix |
|---|---|---|
| \`exasol://user:pw@host\` (stock 7.1+ server, real cert) | ✅ yes (now default TLS) | — |
| \`exasol://user:pw@localhost:8563\` (Docker, self-signed) | ❌ cert validation fails | add \`?validateservercertificate=0\` |
| \`exasol://user:pw@legacy-host\` (pre-7.1, non-TLS) | ❌ server doesn't speak TLS | add \`?tls=false\` |