### PR TITLE
change: upgrade ADBC dependency from 0.22 to 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0
+
+- Upgrade ADBC dependency from 0.22 to 0.23 (breaking: methods now return Box<dyn RecordBatchReader>)
+
 ## 0.8.0
 
 - **Breaking default change**: connections now default to `tls=true` to match the Exasol server 7.1+ requirement and every official Exasol driver (pyexasol, JDBC, Go, ODBC). Callers that relied on the previous `tls=false` default — e.g. to reach legacy (pre-7.1) Exasol servers — must set `?tls=false` explicitly on the connection string or `.use_tls(false)` on the builder.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "adbc_core"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dbe031527c9856a1e2df5e82aa8e568ffaab3be897f70d874477fb42a783bb"
+checksum = "46b169525a7c41670fe95874103c7c6ce713ac699123f81a200bc31f9ad3b02e"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -14,15 +14,17 @@ dependencies = [
 
 [[package]]
 name = "adbc_driver_manager"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5beaa87308b040adcf482fb760f64ced1cbcd9469fe86ddd5be221dabbbc544e"
+checksum = "12aa1ae565ec6d45cfe71c20b5c2b3cbd6ba5d7176ecd0c0a448e970a93c35e4"
 dependencies = [
  "adbc_core",
  "adbc_ffi",
  "arrow-array",
  "arrow-schema",
  "libloading",
+ "path-slash",
+ "regex",
  "toml",
  "windows-registry",
  "windows-sys 0.61.2",
@@ -30,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "adbc_ffi"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3600ae9aec2907516d088189e3b863029280f1953dd0eab903c7f4c862a0ce81"
+checksum = "e6851c2ab953511cf7a244aadcbc0586442fd3c67dfe371457369048880dd513"
 dependencies = [
  "adbc_core",
  "arrow-array",
@@ -1049,7 +1051,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -1878,6 +1880,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pem"
@@ -2919,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3284,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "serde_spanned",
  "toml_datetime",
@@ -3297,27 +3305,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tungstenite"
@@ -3876,9 +3884,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]
@@ -56,8 +56,8 @@ base64 = "0.22"
 num-bigint = "0.4"
 
 # ADBC core traits (optional, for FFI export)
-adbc_core = { version = "0.22.0", optional = true }
-adbc_ffi = { version = "0.22.0", optional = true }
+adbc_core = { version = "0.23.0", optional = true }
+adbc_ffi = { version = "0.23.0", optional = true }
 
 # TLS certificate generation for secure import/export
 rcgen = "0.13"
@@ -94,8 +94,8 @@ polars = { version = "0.46", features = ["lazy", "ipc_streaming", "dtype-decimal
 # Mocking for tests
 mockall = "0.14.0"
 # ADBC driver manager and core for integration testing
-adbc_driver_manager = "0.22"
-adbc_core = "0.22"
+adbc_driver_manager = "0.23"
+adbc_core = "0.23"
 tempfile = "3.24.0"
 # Environment variable loading for examples
 dotenvy = "0.15"

--- a/specs/adbc-driver/driver-interface/spec.md
+++ b/specs/adbc-driver/driver-interface/spec.md
@@ -13,6 +13,7 @@ The system implements the ADBC (Arrow Database Connectivity) driver interface to
 * *GIVEN* an ADBC driver manager is ready to load drivers
 * *WHEN* the driver is loaded by an ADBC driver manager
 * *THEN* it SHALL expose driver metadata including name, version, and vendor information
+* *AND* it SHALL be compatible with ADBC driver manager version 0.23
 
 ### Scenario: Driver initialization
 
@@ -87,3 +88,11 @@ The system implements the ADBC (Arrow Database Connectivity) driver interface to
 * *THEN* the driver SHALL parse `INTERVAL DAY(2) TO SECOND(3)` and `INTERVAL DAY(9) TO SECOND(9)` as valid INTERVAL DAY TO SECOND types
 * *AND* the driver SHALL extract the seconds fraction precision from the SECOND parameter
 * *AND* the driver SHALL NOT return an "Unknown Exasol type" error
+
+### Scenario: Boxed RecordBatchReader return type compliance
+
+* *GIVEN* the ADBC FFI driver is loaded by a driver manager
+* *WHEN* any method that returns query results is called (execute, get_info, get_objects, get_table_types, get_statistic_names, get_statistics, read_partition)
+* *THEN* it SHALL return a `Box<dyn RecordBatchReader + Send>` with `'static` lifetime
+* *AND* the returned reader SHALL be usable after the originating statement or connection method returns
+* *AND* the returned reader SHALL own all its data without borrowing from the statement

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -52,7 +52,7 @@ Exasol lacks an Arrow-native driver. Existing connectors require row-based data 
 | TLS | rustls 0.23 / rcgen 0.13 | Connection encryption and ad-hoc certificate generation for HTTP tunnels |
 | Crypto | aws-lc-rs 1 | RSA encryption for Exasol password authentication |
 | Serialization | serde / serde_json | Exasol WebSocket JSON protocol |
-| ADBC FFI | adbc_core / adbc_ffi 0.21 (optional) | C FFI bindings for driver manager integration |
+| ADBC FFI | adbc_core / adbc_ffi 0.23 (optional) | C FFI bindings for driver manager integration |
 | Testing | cargo test / mockall 0.14 | Unit and integration testing with mocking |
 
 ## Commands

--- a/src/adbc_ffi.rs
+++ b/src/adbc_ffi.rs
@@ -983,7 +983,7 @@ impl adbc_core::Connection for FfiConnection {
     fn get_info(
         &self,
         _codes: Option<HashSet<InfoCode>>,
-    ) -> AdbcResult<impl RecordBatchReader + Send> {
+    ) -> AdbcResult<Box<dyn RecordBatchReader + Send>> {
         // Return driver info as a RecordBatch
         use arrow::array::builder::{StringBuilder, UInt32Builder};
         use arrow::datatypes::{DataType, Field};
@@ -1017,7 +1017,7 @@ impl adbc_core::Connection for FfiConnection {
         )
         .map_err(|e| AdbcError::with_message_and_status(e.to_string(), AdbcStatus::Internal))?;
 
-        Ok(VecRecordBatchReader::new(schema, vec![batch]))
+        Ok(Box::new(VecRecordBatchReader::new(schema, vec![batch])))
     }
 
     fn get_objects(
@@ -1028,7 +1028,7 @@ impl adbc_core::Connection for FfiConnection {
         table_name: Option<&str>,
         table_type: Option<Vec<&str>>,
         column_name: Option<&str>,
-    ) -> AdbcResult<impl RecordBatchReader + Send> {
+    ) -> AdbcResult<Box<dyn RecordBatchReader + Send>> {
         use arrow::array::builder::{
             ArrayBuilder, Int32Builder, ListBuilder, StringBuilder, StructBuilder,
         };
@@ -1039,7 +1039,7 @@ impl adbc_core::Connection for FfiConnection {
             if !cat.eq_ignore_ascii_case("EXA") {
                 // Return empty result with correct schema
                 let schema = Arc::new(build_get_objects_schema());
-                return Ok(VecRecordBatchReader::empty(schema));
+                return Ok(Box::new(VecRecordBatchReader::empty(schema)));
             }
         }
 
@@ -1442,7 +1442,7 @@ impl adbc_core::Connection for FfiConnection {
         )
         .map_err(|e| AdbcError::with_message_and_status(e.to_string(), AdbcStatus::Internal))?;
 
-        Ok(VecRecordBatchReader::new(schema, vec![batch]))
+        Ok(Box::new(VecRecordBatchReader::new(schema, vec![batch])))
     }
 
     fn get_table_schema(
@@ -1535,7 +1535,7 @@ impl adbc_core::Connection for FfiConnection {
         Ok(Schema::new(fields))
     }
 
-    fn get_table_types(&self) -> AdbcResult<impl RecordBatchReader + Send> {
+    fn get_table_types(&self) -> AdbcResult<Box<dyn RecordBatchReader + Send>> {
         use arrow::array::builder::StringBuilder;
         use arrow::datatypes::{DataType, Field};
 
@@ -1553,16 +1553,16 @@ impl adbc_core::Connection for FfiConnection {
         let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(builder.finish())])
             .map_err(|e| AdbcError::with_message_and_status(e.to_string(), AdbcStatus::Internal))?;
 
-        Ok(VecRecordBatchReader::new(schema, vec![batch]))
+        Ok(Box::new(VecRecordBatchReader::new(schema, vec![batch])))
     }
 
-    fn get_statistic_names(&self) -> AdbcResult<impl RecordBatchReader + Send> {
+    fn get_statistic_names(&self) -> AdbcResult<Box<dyn RecordBatchReader + Send>> {
         use arrow::datatypes::{DataType, Field};
         let schema = Arc::new(Schema::new(vec![
             Field::new("statistic_name", DataType::Utf8, false),
             Field::new("statistic_key", DataType::Int16, false),
         ]));
-        Ok(VecRecordBatchReader::empty(schema))
+        Ok(Box::new(VecRecordBatchReader::empty(schema)))
     }
 
     fn get_statistics(
@@ -1571,8 +1571,8 @@ impl adbc_core::Connection for FfiConnection {
         _db_schema: Option<&str>,
         _table_name: Option<&str>,
         _approximate: bool,
-    ) -> AdbcResult<impl RecordBatchReader + Send> {
-        Err::<VecRecordBatchReader, _>(AdbcError::with_message_and_status(
+    ) -> AdbcResult<Box<dyn RecordBatchReader + Send>> {
+        Err::<Box<dyn RecordBatchReader + Send>, _>(AdbcError::with_message_and_status(
             "get_statistics not yet implemented",
             AdbcStatus::NotImplemented,
         ))
@@ -1613,8 +1613,8 @@ impl adbc_core::Connection for FfiConnection {
     fn read_partition(
         &self,
         _partition: impl AsRef<[u8]>,
-    ) -> AdbcResult<impl RecordBatchReader + Send> {
-        Err::<VecRecordBatchReader, _>(AdbcError::with_message_and_status(
+    ) -> AdbcResult<Box<dyn RecordBatchReader + Send>> {
+        Err::<Box<dyn RecordBatchReader + Send>, _>(AdbcError::with_message_and_status(
             "Partitioned results not supported",
             AdbcStatus::NotImplemented,
         ))
@@ -2085,10 +2085,13 @@ impl adbc_core::Statement for FfiStatement {
         Ok(())
     }
 
-    fn execute(&mut self) -> AdbcResult<impl RecordBatchReader + Send> {
+    fn execute(&mut self) -> AdbcResult<Box<dyn RecordBatchReader + Send>> {
         if self.options.contains_key("adbc.ingest.target_table") {
             self.execute_bulk_ingest()?;
-            return Ok(VecRecordBatchReader::new(Arc::new(Schema::empty()), vec![]));
+            return Ok(Box::new(VecRecordBatchReader::new(
+                Arc::new(Schema::empty()),
+                vec![],
+            )));
         }
 
         let sql = self.sql.as_ref().ok_or_else(|| {
@@ -2143,7 +2146,7 @@ impl adbc_core::Statement for FfiStatement {
                 all_batches[0].schema()
             };
 
-            return Ok(VecRecordBatchReader::new(schema, all_batches));
+            return Ok(Box::new(VecRecordBatchReader::new(schema, all_batches)));
         }
 
         let sql = sql.clone();
@@ -2184,7 +2187,7 @@ impl adbc_core::Statement for FfiStatement {
             batches[0].schema()
         };
 
-        Ok(VecRecordBatchReader::new(schema, batches))
+        Ok(Box::new(VecRecordBatchReader::new(schema, batches)))
     }
 
     fn execute_update(&mut self) -> AdbcResult<Option<i64>> {


### PR DESCRIPTION
## Summary

- Upgrade `adbc_core` and `adbc_ffi` from 0.22 to 0.23 to align with [Apache Arrow ADBC Libraries 23](https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-23)
- Fix all 7 FFI method return types: `impl RecordBatchReader + Send` → `Box<dyn RecordBatchReader + Send>` (breaking change in upstream trait)
- Bump exarrow-rs version to 0.9.0

## Affected Methods

| Trait | Method |
|-------|--------|
| Connection | `get_info`, `get_objects`, `get_table_types`, `get_statistic_names`, `get_statistics`, `read_partition` |
| Statement | `execute` |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -W clippy::all` (zero warnings)
- [x] `cargo test --lib` (911 passed)
- [x] `cargo build --release --features ffi`
- [x] `cargo test --test driver_manager_tests` (40 passed)