### PR TITLE
fix: Statement inherits query_timeout from connection params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+- Fixed `query_timeout` connection parameter being ignored — `create_statement()` now applies the configured timeout to every statement instead of using the hardcoded 120s default
+
 ## 0.12.0
 
 - **Native Parquet import on Exasol 2025.1.11+**: When connected to Exasol 2025.1.11 or newer, `import_from_parquet`, `import_from_parquet_stream`, and `import_parquet_from_files` now serve raw Parquet bytes to the server via HTTP range requests instead of converting to CSV. This eliminates client-side CPU cost and reduces wire-bytes by 5–30x for typed columnar data.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]

--- a/specs/adbc-driver/statement-and-results/spec.md
+++ b/specs/adbc-driver/statement-and-results/spec.md
@@ -63,3 +63,10 @@ Statements are pure data objects created via `Connection::create_statement()` an
 * *GIVEN* an active database connection exists
 * *WHEN* result metadata is requested
 * *THEN* it SHALL provide row count, column count, and schema information
+
+### Scenario: Statement inherits connection query timeout
+
+* *GIVEN* a connection is configured with a `query_timeout`
+* *WHEN* `create_statement()` is called on that connection
+* *THEN* the returned Statement SHALL use the connection's configured `query_timeout` as its execution timeout
+* *AND* the Statement SHALL NOT use a hardcoded timeout independent of the connection's configuration

--- a/src/adbc/connection.rs
+++ b/src/adbc/connection.rs
@@ -241,7 +241,9 @@ impl Connection {
     /// # Example
     ///
     pub fn create_statement(&self, sql: impl Into<String>) -> Statement {
-        Statement::new(sql)
+        let mut stmt = Statement::new(sql);
+        stmt.set_timeout(self.params.query_timeout.as_millis() as u64);
+        stmt
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

`Connection::create_statement()` calls `Statement::new()` which hardcodes a 120s timeout default, silently ignoring the `query_timeout` value from `ConnectionParams` (set via URI param `?query_timeout=N` or the builder API).

This causes long-running queries to fail with `Query timeout after 120000ms` even when the connection is explicitly configured with a longer timeout.

**Fix:** `create_statement()` now calls `stmt.set_timeout()` with the connection's `query_timeout`, so all statement paths (`query()`, `execute()`, `execute_update()`) respect the configured value.

## Reproduction

```rust
// URI sets query_timeout=600 (10 minutes)
let conn = Driver::new()
    .open("exasol://user:pass@host:8563?query_timeout=600")?
    .connect().await?;

// Before fix: times out after 120s regardless
// After fix: respects the 600s connection param
conn.query("SELECT * FROM large_table").await?;
```

## Test plan

- [ ] Verify unit test `test_create_statement_default_timeout` still passes
- [ ] Manually verify long-running query respects `query_timeout` URI param