### PR TITLE
chore: bump version to 0.12.2 and fix security advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.2
+
+- Security: upgraded `rustls-webpki` 0.103.11 → 0.103.13 (fixes RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104 — name constraint and CRL parsing vulnerabilities in TLS certificate validation)
+- Security: upgraded `rand` 0.8.5 → 0.8.6 and `rand` 0.9.2 → 0.9.3 (fixes RUSTSEC-2026-0097 — unsoundness with custom logger)
+
 ## 0.12.1
 
 - Fixed `query_timeout` connection parameter being ignored — `create_statement()` now applies the configured timeout to every statement instead of using the hardcoded 120s default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.12.0"
+version = "0.12.2"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -1097,7 +1097,7 @@ dependencies = [
  "num-bigint",
  "parquet",
  "polars",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rcgen",
  "rustls",
  "rustls-native-certs",
@@ -1121,7 +1121,7 @@ dependencies = [
  "chrono",
  "deunicode",
  "dummy",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2082,7 +2082,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_distr",
  "rayon",
  "regex",
@@ -2124,7 +2124,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
 ]
 
@@ -2398,7 +2398,7 @@ dependencies = [
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "sqlparser",
@@ -2426,7 +2426,7 @@ dependencies = [
  "polars-parquet",
  "polars-plan",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "recursive",
  "slotmap",
@@ -2475,7 +2475,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "polars-error",
- "rand 0.8.5",
+ "rand 0.8.6",
  "raw-cpuid",
  "rayon",
  "stacker",
@@ -2582,9 +2582,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2593,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2646,7 +2646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2842,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3370,7 +3370,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-pki-types",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]


### PR DESCRIPTION
Fixes 5 Dependabot findings:
- rustls-webpki 0.103.11 → 0.103.13 (RUSTSEC-2026-0098, -0099, -0104)
- rand 0.8.5 → 0.8.6, rand 0.9.2 → 0.9.3 (RUSTSEC-2026-0097)

Supersedes dependabot/cargo/rustls-webpki-0.103.13 (#32).