### PR TITLE
fix: thrift CVE upgrade arrow 58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.4
+
+- Dependency upgrade: `arrow` and `parquet` 57.x → 58.x; arrow sub-crates unified to a single 58.x version in `Cargo.lock` (fixes a duplicate-version resolver conflict with `adbc_core 0.23.0`).
+- **Note:** `thrift 0.17.0` (Memory Allocation with Excessive Size Value CVE) remains a transitive dependency of `parquet 58.3.0`. It will be removed once `parquet 59.x` ships (upstream PR apache/arrow-rs#9962, merged 2026-05-13, not yet released).
+
 ## 0.12.3
 
 - Fix: `?` characters inside SQL string literals, double-quoted identifiers, and comments are no longer treated as bind-parameter placeholders.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,9 @@ checksum = "ed51fe0f224d1d4ea768be38c51f9f831dee9d05c163c11fba0b8c44387b1fc3"
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -227,7 +227,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -310,15 +310,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
@@ -334,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -347,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -360,18 +361,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -383,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1072,7 +1073,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -1398,6 +1399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,7 +1453,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1675,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -1873,14 +1880,13 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
@@ -1892,7 +1898,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
@@ -3632,7 +3638,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -3642,23 +3648,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -3673,32 +3666,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]
@@ -22,7 +22,7 @@ doctest = false
 
 [dependencies]
 # Apache Arrow support (arrow re-exports arrow-array, arrow-schema, etc.)
-arrow = "57.1.0"
+arrow = "58"
 
 # Async runtime
 tokio = { version = "1.42", features = ["rt-multi-thread", "net", "io-util", "time", "sync", "macros", "fs"] }
@@ -69,7 +69,7 @@ rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", 
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 
 # Parquet file support
-parquet = { version = "57.1.0", features = ["async"] }
+parquet = { version = "58", features = ["async"] }
 
 # Compression support for CSV import/export
 flate2 = "1.1"

--- a/specs/code-quality/core/spec.md
+++ b/specs/code-quality/core/spec.md
@@ -35,3 +35,11 @@ The codebase SHALL maintain zero clippy warnings when built with all targets and
 * *WHEN* clippy fixes are applied
 * *THEN* integration tests against Exasol database MUST pass
 * *AND* driver functionality SHALL remain intact
+
+### Scenario: Arrow and Parquet dependencies resolve to version 58 or above with no duplicate sub-crate versions
+
+* *GIVEN* the resolved dependency tree in `Cargo.lock`
+* *WHEN* inspecting the `[[package]]` entries
+* *THEN* the `arrow` crate MUST resolve to a version `>= 58.0.0`
+* *AND* the `parquet` crate MUST resolve to a version `>= 58.0.0`
+* *AND* the `arrow-array` and `arrow-schema` sub-crates MUST NOT appear at both a 57.x and a 58.x version simultaneously (unified resolution required by `adbc_core 0.23.0`)

--- a/specs/decision-log.md
+++ b/specs/decision-log.md
@@ -85,3 +85,31 @@ Treat bug #18 as not reproducible against the current codebase. Do not apply any
 ### Consequences
 
 The wire-format analysis confirmed that `parse_response` takes the legacy branch for these queries and `parse_result_set_at` decodes `handle=-3 (SMALL_RESULTSET)`, `total_rows=2`, `rows_received=2` and all string values correctly. The most likely explanation for the original user report is that the failure occurred against a pre-0.12.x version or was caused by the placeholder-scanner bug (#17) mangling SQL containing literal `?` characters. Integration tests 4.5–4.8 are present in the codebase as regression guards regardless.
+
+---
+
+## ADR-004: Encode the Arrow/Parquet version invariant as a permanent spec scenario
+
+**Date:** 2026-05-22
+**Plan:** `fix-thrift-cve-upgrade-arrow-58`
+**Status:** Accepted
+
+### Context
+
+The arrow/parquet 57→58 upgrade was driven by a security advisory against the `thrift 0.17.0` transitive dependency. Without a machine-readable invariant in the spec library, a future dependency bump could silently re-introduce `thrift` or revert to a 57.x arrow sub-crate — neither would be caught until a human read `Cargo.lock` manually. The existing `code-quality/core` feature already houses build-output invariants (clippy, test outcomes), making it the natural home for a lockfile-level assertion.
+
+### Decision
+
+Add a new scenario under `code-quality/core` — "Arrow and Parquet dependencies resolve to version 58 or above with no duplicate sub-crate versions" — that asserts `arrow >= 58.0.0`, `parquet >= 58.0.0`, and no simultaneous 57.x/58.x `arrow-array`/`arrow-schema` duplication. Back the scenario with an integration test (`test_arrow_parquet_resolve_to_58_or_above_with_unified_sub_crates`) that reads `Cargo.lock` at test time.
+
+### Options Considered
+
+| Option | Verdict |
+|--------|---------|
+| Encode as a `code-quality/core` scenario + integration test | ✓ Chosen — survives plan completion; future agents see the invariant during `speq search`; automated regression signal |
+| Treat as a one-time dependency bump with no spec change | ✗ Rejected — a future crate addition could silently re-introduce `thrift` with no automated detection |
+| Add a scenario under a new `dependencies/security` domain | ✗ Rejected — only one lockfile-level invariant exists today; a new domain for one scenario is premature organisation |
+
+### Consequences
+
+The CVE-free property is codified in the spec library and verified by CI on every test run. Future dependency upgrades that would reintroduce a 57.x sub-crate duplication or regress the minimum arrow/parquet version will be caught automatically. The scenario must be updated (version floor raised) when the project upgrades past 58.x.

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -49,7 +49,7 @@ Exasol lacks an Arrow-native driver. Existing connectors require row-based data 
 | Language | Rust (2021 edition) | Systems-level performance, memory safety |
 | Async runtime | Tokio 1.42 | Multi-threaded async I/O |
 | WebSocket | tokio-tungstenite 0.28 (optional) | Exasol WebSocket transport with TLS (opt-in fallback) |
-| Arrow | arrow 57.1 / parquet 57.1 | Columnar data format and Parquet I/O |
+| Arrow | arrow 58 / parquet 58 | Columnar data format and Parquet I/O |
 | TLS | rustls 0.23 / rcgen 0.13 | Connection encryption and ad-hoc certificate generation for HTTP tunnels |
 | Crypto | aws-lc-rs 1 | RSA encryption for Exasol password authentication |
 | Stream cipher | chacha20 0.9 / cipher 0.4 | ChaCha20 encryption for native TCP protocol |

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2573,3 +2573,60 @@ async fn test_build_sql_scanner_end_to_end_via_execute_statement() {
 
     conn.close().await.expect("Failed to close connection");
 }
+
+#[test]
+fn test_arrow_parquet_resolve_to_58_or_above_with_unified_sub_crates() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let lockfile = std::fs::read_to_string(format!("{manifest_dir}/Cargo.lock"))
+        .expect("Cargo.lock must be readable");
+
+    let arrow_version = lockfile
+        .lines()
+        .skip_while(|l| !l.contains("name = \"arrow\""))
+        .nth(1)
+        .and_then(|l| l.strip_prefix("version = \""))
+        .and_then(|l| l.strip_suffix('"'))
+        .expect("arrow version not found in Cargo.lock");
+
+    let parquet_version = lockfile
+        .lines()
+        .skip_while(|l| !l.contains("name = \"parquet\""))
+        .nth(1)
+        .and_then(|l| l.strip_prefix("version = \""))
+        .and_then(|l| l.strip_suffix('"'))
+        .expect("parquet version not found in Cargo.lock");
+
+    let arrow_major: u32 = arrow_version
+        .split('.')
+        .next()
+        .unwrap()
+        .parse()
+        .expect("arrow major version must be numeric");
+    let parquet_major: u32 = parquet_version
+        .split('.')
+        .next()
+        .unwrap()
+        .parse()
+        .expect("parquet major version must be numeric");
+
+    assert!(
+        arrow_major >= 58,
+        "arrow must resolve to >= 58.x, got {arrow_version}"
+    );
+    assert!(
+        parquet_major >= 58,
+        "parquet must resolve to >= 58.x, got {parquet_version}"
+    );
+
+    // Verify no duplicate arrow-array at both 57.x and 58.x (adbc_core unification).
+    let arrow_array_57_count = lockfile
+        .lines()
+        .skip_while(|l| !l.contains("name = \"arrow-array\""))
+        .take_while(|l| !l.is_empty())
+        .filter(|l| l.contains("version = \"57."))
+        .count();
+    assert_eq!(
+        arrow_array_57_count, 0,
+        "arrow-array must not appear at a 57.x version alongside 58.x"
+    );
+}


### PR DESCRIPTION
## Summary
  - arrow/parquet 57.x → 58.x; arrow sub-crates unified (fixes adbc_core resolver conflict)
  - Version 0.12.4, CHANGELOG entry with honest CVE note
  - New integration test asserting arrow/parquet ≥ 58.x
  - Spec: new code-quality/core scenario + ADR-004, mission.md updated
