### PR TITLE
fix(adbc): treat a URI-specified schema as a best-effort default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.5
+
+- Fix: a schema named in the connection URI is now a best-effort default. If the schema does not yet exist, `connect()` keeps the connection open (with no active schema) instead of failing, so tools that create their target schema after connecting (e.g. dbt) can bootstrap it. Other `OPEN SCHEMA` failures (auth, permissions, transport) remain fatal. This refines the 0.11.0 behavior, where any schema-activation failure aborted the connection.
+
 ## 0.12.4
 
 - Dependency upgrade: `arrow` and `parquet` 57.x → 58.x; arrow sub-crates unified to a single 58.x version in `Cargo.lock` (fixes a duplicate-version resolver conflict with `adbc_core 0.23.0`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]

--- a/src/adbc/connection.rs
+++ b/src/adbc/connection.rs
@@ -36,6 +36,19 @@ use tokio::time::timeout;
 ///
 pub type Session = Connection;
 
+/// Classify a `set_schema` (`OPEN SCHEMA`) failure as a missing-schema error.
+///
+/// A schema named in the connection URI is a *best-effort default*. When that
+/// schema does not yet exist the server reports a "schema ... not found" error,
+/// which we deliberately swallow during connect so the connection stays open
+/// (see [`Connection::connect_with_transport`]). Any other failure is fatal.
+///
+/// Returns `true` only when the error message indicates the schema was not
+/// found; all other errors return `false`.
+fn schema_open_error_is_missing_schema(err: &QueryError) -> bool {
+    err.to_string().to_ascii_lowercase().contains("not found")
+}
+
 fn blocking_runtime() -> &'static Runtime {
     static RUNTIME: OnceLock<Runtime> = OnceLock::new();
     RUNTIME.get_or_init(|| {
@@ -185,25 +198,36 @@ impl Connection {
             params,
         };
 
-        // If the URI carried a schema, activate it server-side so unqualified
-        // queries work without a follow-up `set_schema()` call. On failure we
-        // must close the transport (we are already authenticated server-side)
-        // before propagating the error — returning a half-open `Connection`
-        // whose session state silently disagrees with the URI is worse than a
-        // clear error.
+        // A schema named in the connection URI is a *best-effort default*: we
+        // OPEN it so unqualified queries resolve against it. A schema that does
+        // not yet exist must NOT fail the connection — tools such as dbt create
+        // their target schema after connecting and fully qualify every relation,
+        // so a not-yet-existing default schema is a normal state, not a corrupt
+        // one. We therefore swallow "schema not found" and leave the session
+        // with no active schema (the schema can be OPENed later, once it exists).
+        //
+        // Any other failure (auth, transport, permissions) still indicates a
+        // genuinely broken connection: we close the transport — we are already
+        // authenticated server-side — and propagate a clear error rather than
+        // return a half-open `Connection`.
         if let Some(schema_name) = schema {
             if let Err(query_err) = connection.set_schema(schema_name.clone()).await {
-                let host = connection.params.host.clone();
-                let port = connection.params.port;
-                let _ = connection.shutdown().await;
-                return Err(ConnectionError::ConnectionFailed {
-                    host,
-                    port,
-                    message: format!(
-                        "failed to activate schema '{}' from connection URI: {}",
-                        schema_name, query_err
-                    ),
-                });
+                let schema_missing = schema_open_error_is_missing_schema(&query_err);
+                if !schema_missing {
+                    let host = connection.params.host.clone();
+                    let port = connection.params.port;
+                    let _ = connection.shutdown().await;
+                    return Err(ConnectionError::ConnectionFailed {
+                        host,
+                        port,
+                        message: format!(
+                            "failed to activate schema '{}' from connection URI: {}",
+                            schema_name, query_err
+                        ),
+                    });
+                }
+                // Schema does not exist yet: keep the connection open with no
+                // active schema. Fully qualified names continue to work.
             }
         }
 
@@ -2063,6 +2087,35 @@ mod tests {
         // by calling it without await
         // Note: We can't actually create a Connection without a database,
         // but we can verify the API compiles correctly
+    }
+
+    /// Regression test for the best-effort URI-schema fix.
+    ///
+    /// A schema named in the connection URI that does not yet exist must NOT
+    /// fail the connection: the server reports a "schema ... not found" error
+    /// (real Exasol message format), which `connect_with_transport` swallows so
+    /// the connection stays open. Every other failure must remain fatal.
+    #[test]
+    fn schema_open_error_missing_schema_is_recognized() {
+        // Real Exasol-style "OPEN SCHEMA" failure for a non-existent schema.
+        let missing = QueryError::ExecutionFailed(
+            "Protocol error: schema FOO not found [line 1, column 13] (SQL state: 42000)"
+                .to_string(),
+        );
+        assert!(
+            schema_open_error_is_missing_schema(&missing),
+            "a 'schema ... not found' error must be classified as missing-schema (swallowed)"
+        );
+    }
+
+    #[test]
+    fn schema_open_error_unrelated_is_fatal() {
+        // An unrelated failure (e.g. permissions) must stay fatal.
+        let unrelated = QueryError::ExecutionFailed("insufficient privileges".to_string());
+        assert!(
+            !schema_open_error_is_missing_schema(&unrelated),
+            "an unrelated error must NOT be classified as missing-schema (stays fatal)"
+        );
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -449,6 +449,47 @@ async fn test_create_schema() {
     conn.close().await.expect("Failed to close connection");
 }
 
+/// Best-effort URI-schema regression (live behavior).
+///
+/// Connecting with a URI schema that does NOT yet exist must succeed: the
+/// "schema ... not found" failure from the implicit `OPEN SCHEMA` is swallowed
+/// and the connection stays open with no active schema. Tools such as dbt rely
+/// on this so they can create their target schema after connecting.
+///
+/// Documents the live behavior; run with `--ignored` against a real Exasol.
+#[tokio::test]
+#[ignore]
+async fn test_connect_with_nonexistent_uri_schema_succeeds() {
+    skip_if_no_exasol!();
+
+    let schema_name = generate_test_schema_name();
+
+    // Connect requesting a default schema that does not exist yet.
+    let conn = Connection::builder()
+        .host(&get_host())
+        .port(get_port())
+        .username(&get_user())
+        .password(&common::get_password())
+        .schema(&schema_name)
+        .use_tls(false)
+        .connect()
+        .await;
+
+    assert!(
+        conn.is_ok(),
+        "Connecting with a non-existent URI schema should succeed (best-effort default), got: {:?}",
+        conn.err()
+    );
+
+    let conn = conn.unwrap();
+    assert!(
+        !conn.is_closed().await,
+        "Connection should stay open even though the URI schema does not exist"
+    );
+
+    conn.close().await.expect("Failed to close connection");
+}
+
 /// 4.2 Test CREATE TABLE with various column types
 #[tokio::test]
 async fn test_create_table_various_types() {


### PR DESCRIPTION
## Problem

A schema named in the connection URI (`exasol://host:port/SCHEMA`) is opened eagerly right after login via `OPEN SCHEMA`. Today **any** failure of that statement aborts the whole connection (`connect_with_transport` shuts the transport down and returns `ConnectionFailed`).

That makes the URI schema a hard precondition rather than a default, which breaks tools that connect first and create their target schema afterwards. dbt (both dbt-core and dbt Fusion) is the motivating case: it opens a connection, then runs `CREATE SCHEMA IF NOT EXISTS ...` in its run-start hook and fully qualifies every relation. At connect time the schema does not exist yet, so the connection fails with:

```
failed to activate schema 'MY_SCHEMA' from connection URI:
  ... schema MY_SCHEMA not found [line 1, column 13] (SQL state: 42000)
```

i.e. you can't connect to create the schema because connecting requires the schema to already exist.

## Fix

Treat a URI-specified schema as a **best-effort default**:

- If `OPEN SCHEMA` fails because the schema does not exist (`"schema ... not found"`), keep the connection open with **no active schema**. Fully qualified names keep working, and the schema can be `OPEN`ed later once it exists.
- Any **other** failure (auth, transport, permissions) stays fatal and closes the transport, exactly as before — we never return a half-open connection for a genuinely broken state.

This matches how a connection default schema behaves in other mature drivers, and aligns with the documented behavior in `lib.rs` ("Schema in the URI is automatically opened with `OPEN SCHEMA` after login").

The missing-schema classification is extracted into a small helper (`schema_open_error_is_missing_schema`) so it is unit-testable.

## Behavior change

Only the **missing-schema** case changes: previously a hard `ConnectionFailed`, now a successful connection with no active schema. All other connect/auth/transport errors are unchanged.

## Tests

- Unit tests (`cargo test --lib adbc::connection`): a real Exasol-style `"schema ... not found"` message is classified as missing-schema (swallowed); an unrelated error stays fatal.
- An `#[ignore]`d live integration test (`test_connect_with_nonexistent_uri_schema_succeeds`) documenting that connecting with a non-existent URI schema returns `Ok` and the connection stays open. Run with `--ignored` against a live Exasol (per CONTRIBUTING).

## Notes

- Detection is message-based (`contains("not found")`) since the schema-open error currently surfaces as a `QueryError::ExecutionFailed(String)`. Happy to tighten to the SQL state (`42000`) if the error type is later enriched with structured codes.
- Motivated by bringing up the Exasol adapter on dbt Fusion (dbt-core v2), where exarrow-rs is the ADBC driver and dbt manages schema creation.