### PR TITLE
fix(adbc): zero-row result sets carry their column schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.7
+
+- Fix: zero-row result sets now carry their column schema. `ResultSet::from_transport_result` previously produced an empty batch list for a result with no rows, so the schema (built from the result set's column metadata, which Exasol always returns) was lost. Consumers that read the schema from the first batch — notably the ADBC `RecordBatchReader` used by dbt Fusion for `SELECT ... WHERE FALSE LIMIT 0` schema probes — saw zero columns. An empty result set now yields a single zero-row batch carrying the schema. Affected dbt Fusion snapshots, contracts, unit tests, and `get_columns_in_query`.
+
 ## 0.12.6
 
 - Security: GHSA-2f9f-gq7v-9h6m (CVE-2026-43868, Apache Thrift CWE-789, CVSS 5.3 Medium) formally suppressed in `deny.toml`. No patch is available on crates.io (`thrift 0.23.0` unpublished; `parquet ^0.17` blocks `[patch.crates-io]` override; `parquet 59.x`, which removes thrift, not yet released). Re-evaluate when `parquet 59.x` ships or `adbc_core` supports `arrow-schema >=59`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.12.6"
+version = "0.12.7"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]

--- a/specs/adbc-driver/statement-and-results/spec.md
+++ b/specs/adbc-driver/statement-and-results/spec.md
@@ -56,7 +56,8 @@ Statements are pure data objects created via `Connection::create_statement()` an
 
 * *GIVEN* an active database connection exists
 * *WHEN* a query returns no rows
-* *THEN* it SHALL return an empty RecordBatch with correct schema
+* *THEN* it SHALL return exactly one Arrow RecordBatch with zero rows
+* *AND* that RecordBatch SHALL carry the correct column schema (column names and Arrow data types)
 
 ### Scenario: Result set metadata
 
@@ -70,3 +71,10 @@ Statements are pure data objects created via `Connection::create_statement()` an
 * *WHEN* `create_statement()` is called on that connection
 * *THEN* the returned Statement SHALL use the connection's configured `query_timeout` as its execution timeout
 * *AND* the Statement SHALL NOT use a hardcoded timeout independent of the connection's configuration
+
+### Scenario: Empty result schema surfaced via RecordBatchReader
+
+* *GIVEN* an ADBC statement is executed whose query returns zero rows (for example a `SELECT ... WHERE FALSE LIMIT 0` schema probe)
+* *WHEN* the resulting RecordBatchReader's schema is read from its first batch
+* *THEN* the RecordBatchReader SHALL surface the full column schema (column names and Arrow data types)
+* *AND* it SHALL NOT fall back to an empty schema with zero columns

--- a/specs/connection-management/session-and-lifecycle/spec.md
+++ b/specs/connection-management/session-and-lifecycle/spec.md
@@ -4,7 +4,7 @@ Specifies session management, connection pooling foundation, and timeout configu
 
 ## Background
 
-The system SHALL manage database session lifecycle from establishment through termination. Connections SHALL support clean state reset to enable future pooling implementations. Configurable timeouts SHALL govern connection, query, and idle operations with sensible defaults. When the connection URI or `ConnectionParams` carries a schema, the driver SHALL eagerly activate that schema server-side during `connect()` so unqualified statements resolve immediately, matching the behavior of pyexasol and other ADBC drivers.
+The system SHALL manage database session lifecycle from establishment through termination. Connections SHALL support clean state reset to enable future pooling implementations. Configurable timeouts SHALL govern connection, query, and idle operations with sensible defaults. When the connection URI or `ConnectionParams` carries a schema, the driver SHALL treat that schema as a best-effort default: it SHALL attempt to activate the schema server-side during `connect()` so unqualified statements resolve immediately, but a schema that does not yet exist SHALL NOT abort the connection. This matches tools such as dbt, which connect first and create their target schema afterwards while fully qualifying every relation, so a not-yet-existing default schema is a normal state rather than a fatal error.
 
 ## Scenarios
 
@@ -21,8 +21,8 @@ The system SHALL manage database session lifecycle from establishment through te
 * *WHEN* session attributes are requested
 * *THEN* it SHALL provide current schema, session ID, and other metadata
 * *AND* it SHALL allow setting session attributes (e.g., current schema)
-* *AND* when a schema is supplied via the connection URI or `ConnectionParams.schema`, it SHALL apply that schema server-side during `connect()` so that subsequent statements resolve unqualified identifiers against it without an additional client call
-* *AND* if the server-side schema activation fails, `connect()` MUST return a `ConnectionError` and MUST NOT leave a half-open connection visible to the caller
+* *AND* when a schema is supplied via the connection URI or `ConnectionParams.schema`, it SHALL attempt to apply that schema server-side during `connect()` so that subsequent statements resolve unqualified identifiers against it without an additional client call
+* *AND* if the server-side schema activation fails for any reason OTHER than the schema not existing (for example authentication, permissions, or transport errors), `connect()` MUST return a `ConnectionError` and MUST NOT leave a half-open connection visible to the caller
 
 ### Scenario: Session termination
 
@@ -76,7 +76,16 @@ The system SHALL manage database session lifecycle from establishment through te
 
 ### Scenario: Schema activation failure surfaces during connect
 
-* *GIVEN* a `Database` configured with a non-existent schema in the connection params
+* *GIVEN* a `Database` configured with a schema in the connection params whose activation fails for a reason OTHER than the schema not existing (for example insufficient privileges)
 * *WHEN* the application calls `Database::connect()`
 * *THEN* `connect()` MUST return a `ConnectionError` whose source identifies the schema activation failure
 * *AND* the underlying transport session MUST be closed before the error is returned so that no leaked session remains on the server
+
+### Scenario: Non-existent URI schema is a best-effort default
+
+* *GIVEN* a `Database` configured with a connection string of the form `exasol://user:pass@host/SCHEMA_NAME` where `SCHEMA_NAME` does not yet exist on the server
+* *WHEN* the application calls `Database::connect()` (or the equivalent ADBC FFI path)
+* *THEN* `connect()` MUST succeed and return an open `Connection` rather than returning an error
+* *AND* the driver MUST swallow the "schema not found" failure from the implicit `OPEN SCHEMA` and leave the session with no active schema, so the returned `Connection` MUST NOT report `SCHEMA_NAME` from `current_schema()`
+* *AND* a subsequent fully-qualified `SELECT * FROM SCHEMA_NAME.TABLE_X` (once the schema and table exist) MUST resolve normally, and the caller MAY activate `SCHEMA_NAME` later via `set_schema()` once it has been created
+* *AND* the driver SHALL classify the failure as a missing-schema error by a message-based check (it inspects the server error text for a "not found" indication), which is a known limitation if the server changes its error wording

--- a/specs/decision-log.md
+++ b/specs/decision-log.md
@@ -142,3 +142,31 @@ Add a suppression entry for GHSA-2f9f-gq7v-9h6m to `deny.toml` with a structured
 ### Consequences
 
 The advisory is formally closed in Dependabot with a traceable rationale. Future maintainers have a concrete re-evaluation trigger. The `cargo deny check advisories` CI gate ensures any new unacknowledged advisory blocks merge automatically. When `parquet 59.x` is released or `adbc_core` lifts the `arrow-schema <59` cap, the suppression entry should be removed and a clean `cargo update` attempted.
+
+---
+
+## ADR-006: Zero-row result sets carry their column schema
+
+**Date:** 2026-06-09
+**Plan:** `fix-zero-row-result-schema`
+**Status:** Accepted
+
+### Context
+
+`ResultSet::from_transport_result` built the Arrow schema from the result set's column metadata (always present, even with no rows) but then produced an empty `Vec<RecordBatch>` whenever the first data payload had zero rows. The schema lived only on `QueryMetadata`, so any consumer that reads the schema from the batches lost the columns. The ADBC FFI layer (`FfiStatement::execute`) does exactly this: with no batches it falls back to `Schema::empty()`. dbt Fusion derives a query's column schema via `get_empty_subquery_sql` (`SELECT * FROM (...) WHERE FALSE LIMIT 0`); the empty schema made it see zero columns, breaking snapshots (`get_snapshot_get_time_data_type` indexing `[0]` on an empty list), contract validation (`get_assert_columns_equivalent`), unit tests, and `get_columns_in_query`. `payload_to_record_batch`/`column_major_to_record_batch` already build a correct zero-row batch from the schema, so the bug was purely the empty-list short-circuit.
+
+### Decision
+
+In `from_transport_result`, always emit one batch for a result set: when the payload is empty, build a zero-row batch from the authoritative column schema (new `empty_record_batch` helper) instead of returning `Vec::new()`. A result set always has columns, so it always yields at least one schema-carrying batch.
+
+### Options Considered
+
+| Option | Verdict |
+|--------|---------|
+| Emit a zero-row batch built from the column schema | ✓ Chosen — fixes the deficiency at its source; schema is conveyed uniformly regardless of row count or downstream consumer |
+| Fix only the ADBC `execute()` fallback to reuse `QueryMetadata.schema` | ✗ Rejected — leaves the empty-batch-list footgun for every other consumer (`fetch_all`, iterators) |
+| Work around it downstream (e.g. dbt `LIMIT 1` probe) | ✗ Rejected — a band-aid in every consumer for a driver-layer defect; an empty result set legitimately has columns |
+
+### Consequences
+
+Empty result sets behave like every other ADBC driver's: the schema survives zero rows. dbt Fusion schema introspection (snapshots, contracts, unit tests, `get_columns_in_query`) works against Exasol without consumer-side workarounds. Regression test `test_empty_result_set_preserves_schema` guards it.

--- a/specs/decision-log.md
+++ b/specs/decision-log.md
@@ -170,3 +170,31 @@ In `from_transport_result`, always emit one batch for a result set: when the pay
 ### Consequences
 
 Empty result sets behave like every other ADBC driver's: the schema survives zero rows. dbt Fusion schema introspection (snapshots, contracts, unit tests, `get_columns_in_query`) works against Exasol without consumer-side workarounds. Regression test `test_empty_result_set_preserves_schema` guards it.
+
+---
+
+## ADR-007: A URI-specified schema is a best-effort default, not a connect-time requirement
+
+**Date:** 2026-06-08
+**Plan:** `change-uri-schema-best-effort`
+**Status:** Accepted
+
+### Context
+
+In 0.11.0 a schema named in the connection URI was opened eagerly after login via `OPEN SCHEMA`, and ANY failure of that implicit activation aborted the connection: `connect_with_transport` closed the transport and returned `ConnectionError::ConnectionFailed`. The spec encoded this as a hard requirement ("if the server-side schema activation fails, `connect()` MUST return a `ConnectionError`"). This breaks tools such as dbt, which connect first and create their target schema afterwards while fully qualifying every relation. At connect time the schema does not exist yet, so the connection failed before the tool could create it -- a normal bootstrap state was treated as fatal.
+
+### Decision
+
+Treat a URI-specified schema as a best-effort default. During `connect_with_transport`, if the implicit `set_schema` (`OPEN SCHEMA`) fails, classify the failure: if it is a missing-schema error, swallow it and leave the session open with no active schema (the schema can be `OPEN`ed later, once it exists); if it is any other failure, keep the existing fatal behavior -- close the transport and return `ConnectionError::ConnectionFailed`. Classification is performed by a small free function `schema_open_error_is_missing_schema(&QueryError) -> bool` that inspects the lowercased error message for "not found".
+
+### Options Considered
+
+| Option | Verdict |
+|--------|---------|
+| Best-effort default: swallow missing-schema, keep other failures fatal | Chosen -- unblocks dbt-style bootstrap while preserving the safety guarantee that a genuinely broken connection never returns a half-open `Connection` |
+| Keep any schema-activation failure fatal (0.11.0 behavior) | Rejected -- treats a normal not-yet-existing default schema as a corrupt connection; blocks dbt and similar tools |
+| Eagerly `CREATE SCHEMA` the missing schema during connect | Rejected -- the driver must not silently perform DDL or assume create permissions on the user's behalf; schema creation is the application's decision |
+
+### Consequences
+
+dbt and similar tools can connect against a not-yet-existing default schema and create it afterwards; fully qualified relations continue to resolve, and the caller may activate the schema later via `set_schema()`. Non-missing failures (auth, permissions, transport) still close the transport and return a clear error, so no half-open connection is ever leaked. The missing-schema classification is message-based (substring "not found" on the lowercased error text), which is a known brittleness: if Exasol changes its "schema ... not found" wording, a missing schema could be misclassified as fatal (or vice versa). The behavior is guarded by unit tests `schema_open_error_missing_schema_is_recognized` and `schema_open_error_unrelated_is_fatal`, and by the ignored live integration test `test_connect_with_nonexistent_uri_schema_succeeds`.

--- a/specs/query-execution/results-and-transactions/spec.md
+++ b/specs/query-execution/results-and-transactions/spec.md
@@ -30,6 +30,7 @@ Query results are retrieved efficiently with support for both small single-fetch
 * *THEN* it SHALL provide column names and types
 * *AND* it SHALL provide row count (if available)
 * *AND* it SHALL provide Arrow schema
+* *AND* the Arrow schema SHALL be available regardless of how many rows the result set contains, including zero rows
 
 ### Scenario: Explicit transaction begin
 
@@ -93,3 +94,12 @@ Query results are retrieved efficiently with support for both small single-fetch
 * *WHEN* EXPLAIN is used
 * *THEN* it SHALL return query execution plan information
 * *AND* it SHALL format plan data appropriately for display
+
+### Scenario: Zero-row result set preserves schema
+
+* *GIVEN* a query has been executed
+* *WHEN* the query returns a result set with zero rows
+* *THEN* it SHALL yield exactly one Arrow RecordBatch
+* *AND* that RecordBatch SHALL have a row count of zero
+* *AND* that RecordBatch SHALL carry the full column schema (column names and Arrow data types) derived from the result set's column metadata
+* *AND* it SHALL NOT return an empty batch list that drops the schema

--- a/src/query/results.rs
+++ b/src/query/results.rs
@@ -111,12 +111,19 @@ impl ResultSet {
 
                 let num_rows_received = data.data.num_rows() as i64;
 
-                let batches = if data.data.is_empty() {
-                    Vec::new()
+                // A result set always carries column metadata, even with zero rows.
+                // Emit one (possibly empty) batch built from that schema so consumers
+                // that read the schema from the first batch (e.g. ADBC's
+                // RecordBatchReader, used by dbt Fusion for `WHERE FALSE LIMIT 0`
+                // schema probes) still receive the columns. Returning an empty Vec
+                // here would drop the schema for zero-row results.
+                let batch = if data.data.is_empty() {
+                    Self::empty_record_batch(&schema)
                 } else {
-                    vec![Self::payload_to_record_batch(&data, &schema)
-                        .map_err(|e| QueryError::ExecutionFailed(e.to_string()))?]
-                };
+                    Self::payload_to_record_batch(&data, &schema)
+                }
+                .map_err(|e| QueryError::ExecutionFailed(e.to_string()))?;
+                let batches = vec![batch];
 
                 let complete = handle.is_none() || data.total_rows == num_rows_received;
 
@@ -315,6 +322,23 @@ impl ResultSet {
             ResultPayload::Arrow(batch) => Ok(batch.clone()),
             ResultPayload::Json(_) => Self::column_major_to_record_batch(data, schema),
         }
+    }
+
+    /// Build a zero-row RecordBatch that carries the given schema.
+    ///
+    /// Used for empty result sets so the column schema is still conveyed to
+    /// consumers that read it from the first batch (the schema itself comes
+    /// from the result set's column metadata, which is present even with no
+    /// rows).
+    fn empty_record_batch(schema: &Arc<Schema>) -> Result<RecordBatch, ConversionError> {
+        use arrow::array::{new_empty_array, Array};
+        let arrays: Vec<Arc<dyn Array>> = schema
+            .fields()
+            .iter()
+            .map(|field| new_empty_array(field.data_type()))
+            .collect();
+        RecordBatch::try_new(Arc::clone(schema), arrays)
+            .map_err(|e| ConversionError::ArrowError(e.to_string()))
     }
 
     /// Convert row-major JSON result data to RecordBatch.
@@ -872,6 +896,67 @@ mod tests {
         assert_eq!(metadata.column_count, 2);
         assert_eq!(metadata.total_rows, Some(2));
         assert_eq!(metadata.column_names(), vec!["id", "name"]);
+    }
+
+    #[tokio::test]
+    async fn test_empty_result_set_preserves_schema() {
+        // A zero-row result set must still convey its columns: ADBC consumers
+        // read the schema from the first batch, so an empty Vec would drop it
+        // (regression test for `WHERE FALSE LIMIT 0` schema probes).
+        let mock_transport = MockTransport::new();
+        let transport: Arc<Mutex<dyn TransportProtocol>> = Arc::new(Mutex::new(mock_transport));
+
+        let data = ResultData {
+            columns: vec![
+                ColumnInfo {
+                    name: "id".to_string(),
+                    data_type: DataType {
+                        type_name: "DECIMAL".to_string(),
+                        precision: Some(18),
+                        scale: Some(0),
+                        size: None,
+                        character_set: None,
+                        with_local_time_zone: None,
+                        fraction: None,
+                    },
+                },
+                ColumnInfo {
+                    name: "name".to_string(),
+                    data_type: DataType {
+                        type_name: "VARCHAR".to_string(),
+                        precision: None,
+                        scale: None,
+                        size: Some(100),
+                        character_set: Some("UTF8".to_string()),
+                        with_local_time_zone: None,
+                        fraction: None,
+                    },
+                },
+            ],
+            data: ResultPayload::Json(vec![]),
+            total_rows: 0,
+        };
+
+        let result = TransportQueryResult::ResultSet { handle: None, data };
+        let result_set = ResultSet::from_transport_result(result, transport).unwrap();
+
+        let batches = result_set.fetch_all().await.unwrap();
+        assert_eq!(
+            batches.len(),
+            1,
+            "empty result set must yield one schema-carrying batch"
+        );
+        assert_eq!(batches[0].num_rows(), 0);
+        assert_eq!(batches[0].num_columns(), 2);
+        assert_eq!(
+            batches[0]
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect::<Vec<_>>(),
+            vec!["id", "name"]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`ResultSet::from_transport_result` builds the Arrow schema from the result set's column metadata (always present, even with zero rows) but then returns an **empty `Vec<RecordBatch>`** whenever the first data payload has no rows. The schema lives only on `QueryMetadata`, so any consumer that reads the schema from the batches loses the columns.

The ADBC FFI layer does exactly this — `FfiStatement::execute` falls back to `Schema::empty()` when there are no batches. dbt Fusion derives a query's column schema via an empty-subquery probe (`SELECT * FROM (...) WHERE FALSE LIMIT 0`); the empty schema makes it see **zero columns**, breaking:

- snapshots (`get_snapshot_get_time_data_type` indexes `[0]` on an empty schema list → undefined)
- contract validation (`get_assert_columns_equivalent`)
- unit tests
- `get_columns_in_query`

`payload_to_record_batch` / `column_major_to_record_batch` already build a correct zero-row batch from the schema, so the defect was purely the empty-list short-circuit.

## Fix

In `from_transport_result`, always emit one batch: when the payload is empty, build a zero-row batch from the authoritative column schema (new `empty_record_batch` helper) instead of returning `Vec::new()`. A result set always has columns, so it always yields at least one schema-carrying batch — matching every other ADBC driver's behavior.

## Tests

- New regression test `test_empty_result_set_preserves_schema`: a zero-row result set yields one batch with the correct columns.
- Full lib suite: 1024 passed, `cargo clippy` clean.
- Verified end-to-end against dbt Fusion on a local Exasol: snapshot create + SCD2 and contract introspection now succeed with the standard `WHERE FALSE LIMIT 0` probe (previously crashed).

Bumps to 0.12.7; records ADR-006.

---

## Specs (speq)

Authored retrospectively with `speq`. This PR also backfills the spec for the **already-merged #39** (URI-specified schema as a best-effort default), so the two related changes land their specs together. `speq decision-log validate` passes.

- `query-execution/results-and-transactions` — new scenario *Zero-row result set preserves schema*; *Result set metadata* amended (Arrow schema available regardless of row count)
- `adbc-driver/statement-and-results` — tightened *Empty result sets*; new *Empty result schema surfaced via RecordBatchReader* (the dbt Fusion consumer contract)
- `connection-management/session-and-lifecycle` (**#39 backfill**) — best-effort default schema in Background + *Session attributes*; existing failure scenario scoped to non-missing causes; new *Non-existent URI schema is a best-effort default*
- `specs/decision-log.md` — ADR-007 (#39); ADR-006 (this fix) recorded with the code commit
