### PR TITLE
feat(adbc): multi-row batch prepared-statement execution (v0.12.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.8
+
+- Feat: two new `Connection` methods for multi-row prepared-statement execution: `execute_batch_update` (executes a batch and returns the total affected row count) and `execute_batch` (executes a batch and returns a `ResultSet`). Both accept a slice of row parameter sets and handle column-major wire encoding internally.
+- Feat: `PreparedStatement::build_batch_parameters_data` — a builder that assembles row-major batch parameters (a slice of per-row `Vec<Parameter>`) into the column-major wire form required by the Exasol protocol.
+- No breaking changes; all additions are backward-compatible.
+
 ## 0.12.7
 
 - Fix: zero-row result sets now carry their column schema. `ResultSet::from_transport_result` previously produced an empty batch list for a result with no rows, so the schema (built from the result set's column metadata, which Exasol always returns) was lost. Consumers that read the schema from the first batch — notably the ADBC `RecordBatchReader` used by dbt Fusion for `SELECT ... WHERE FALSE LIMIT 0` schema probes — saw zero columns. An empty result set now yields a single zero-row batch carrying the schema. Affected dbt Fusion snapshots, contracts, unit tests, and `get_columns_in_query`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]

--- a/specs/decision-log.md
+++ b/specs/decision-log.md
@@ -173,6 +173,34 @@ Empty result sets behave like every other ADBC driver's: the schema survives zer
 
 ---
 
+## ADR-008: Fail-fast per-row arity check before any transport call in batch execution
+
+**Date:** 2026-06-19
+**Plan:** `add-batch-prepared-execution`
+**Status:** Accepted
+
+### Context
+
+`build_batch_parameters_data` transposes a row-major slice of `Parameter` rows into column-major wire data. Column-major assembly requires that every input row has the same length as `parameter_count()`. A row of the wrong width would silently misalign columns and corrupt the batch on the wire — column `c` would contain values from multiple different logical columns. This class of silent data corruption is worse than a binding error because it produces wrong results rather than an obvious failure.
+
+### Decision
+
+Each input row's length MUST equal `parameter_count()`. If any row's length differs, return `QueryError::ParameterBindingError` before assembling any columns or making any transport call.
+
+### Options Considered
+
+| Option | Verdict |
+|--------|---------|
+| Fail-fast arity check before column assembly | ✓ Chosen — prevents silent column misalignment; consistent with the principle that validation must precede I/O |
+| Trust the caller (no arity check) | ✗ Rejected — wrong-width rows silently corrupt column-major data on the wire, producing incorrect query results |
+| Pad or truncate rows to fit `parameter_count()` | ✗ Rejected — silently discards or fabricates parameter values; caller intent cannot be inferred from mismatched arity |
+
+### Consequences
+
+Any caller supplying rows of inconsistent or wrong arity receives an immediate `ParameterBindingError` with no transport call made. Future maintainers extending the batch path MUST preserve this invariant: column-major transpose correctness depends on uniform row width. The check is unit-tested via `test_build_batch_params_arity_mismatch`.
+
+---
+
 ## ADR-007: A URI-specified schema is a best-effort default, not a connect-time requirement
 
 **Date:** 2026-06-08

--- a/specs/prepared-statements/batch-execution/spec.md
+++ b/specs/prepared-statements/batch-execution/spec.md
@@ -1,0 +1,59 @@
+# Feature: Batch Execution
+
+Specifies multi-row batch execution of prepared statements, including column-major parameter assembly, batch update and query methods, arity validation, and edge-case behavior for empty batches and closed statements.
+
+## Background
+
+A batch of rows (each row a list of positional parameters) can be assembled into column-major wire data and executed in a single prepared-statement call. This enables efficient bulk DML and parameterized queries without per-row round trips. The transport layer accepts N-row column-major parameter data natively; batch execution is therefore a pure API-surface addition over the single-row execution path.
+
+## Scenarios
+
+### Scenario: Batch parameter data assembly in column-major form
+
+* *GIVEN* a prepared statement with a known parameter count
+* *WHEN* batch parameter data is built from a slice of rows, where each row is a list of `Parameter` values
+* *THEN* the system SHALL produce one column per parameter position
+* *AND* each column SHALL contain one wire-protocol value per input row, in input row order
+* *AND* the value at column `c` row `r` SHALL equal the wire-protocol conversion of the parameter at position `c` in input row `r`
+* *AND* binary parameters SHALL be hex-encoded identically to single-row execution
+
+### Scenario: Batch update execution with affected row count
+
+* *GIVEN* a prepared INSERT/UPDATE/DELETE statement and multiple rows of bound parameter values
+* *WHEN* the batch is executed for an affected-row-count result
+* *THEN* the system SHALL send all rows to Exasol in a single prepared-statement execution
+* *AND* the system SHALL return the total number of affected rows
+* *AND* the system SHALL reuse the server-side prepared statement without re-parsing the SQL
+
+### Scenario: Batch query execution returning a result set
+
+* *GIVEN* a prepared statement and multiple rows of bound parameter values
+* *WHEN* the batch is executed for a result set
+* *THEN* the system SHALL send all rows to Exasol in a single prepared-statement execution
+* *AND* the system SHALL return the result set in Arrow form
+
+### Scenario: Batch execution with parameter arity mismatch
+
+* *GIVEN* a prepared statement with a known parameter count
+* *WHEN* a batch is supplied in which any row's parameter count differs from the statement's parameter count
+* *THEN* the system MUST reject the batch with a parameter binding error
+* *AND* the system MUST NOT send any data to Exasol
+
+### Scenario: Empty batch execution
+
+* *GIVEN* a prepared statement
+* *WHEN* a batch is supplied with zero rows
+* *THEN* the system SHALL treat the batch as carrying no parameter data
+* *AND* the system SHALL NOT report a parameter binding error for the empty batch
+
+### Scenario: Batch execution on a closed statement
+
+* *GIVEN* a prepared statement that has been closed
+* *WHEN* a batch execution is attempted on it
+* *THEN* the system MUST reject the execution with a statement-closed error
+
+### Scenario: Batch update rejects a result-set response
+
+* *GIVEN* a prepared statement executed as a batch update
+* *WHEN* Exasol returns a result set instead of an affected-row count
+* *THEN* the system MUST reject the outcome with an unexpected-result-set error

--- a/src/adbc/connection.rs
+++ b/src/adbc/connection.rs
@@ -15,6 +15,7 @@ use crate::connection::session::{Session as SessionInfo, SessionConfig, SessionS
 use crate::error::{ConnectionError, ExasolError, QueryError};
 use crate::query::prepared::PreparedStatement;
 use crate::query::results::ResultSet;
+use crate::query::statement::Parameter;
 use crate::transport::protocol::{
     ConnectionParams as TransportConnectionParams, Credentials as TransportCredentials,
     QueryResult, TransportProtocol,
@@ -498,6 +499,116 @@ impl Connection {
             QueryResult::RowCount { count } => Ok(count),
             QueryResult::ResultSet { .. } => Err(QueryError::UnexpectedResultSet),
         }
+    }
+
+    /// Execute a prepared statement with multiple rows of parameters and return the number of
+    /// affected rows.
+    ///
+    /// Use this for batch INSERT, UPDATE, or DELETE statements.
+    ///
+    /// # Arguments
+    ///
+    /// * `stmt` - Prepared statement to execute
+    /// * `rows` - Slice of parameter rows; each row is a `Vec<Parameter>` in positional order
+    ///
+    /// # Returns
+    ///
+    /// The total number of rows affected.
+    ///
+    /// # Errors
+    ///
+    /// Returns `QueryError` if execution fails, if the statement is closed, or if Exasol
+    /// returns a result set instead of an affected-row count.
+    pub async fn execute_batch_update(
+        &mut self,
+        stmt: &PreparedStatement,
+        rows: &[Vec<Parameter>],
+    ) -> Result<i64, QueryError> {
+        if stmt.is_closed() {
+            return Err(QueryError::StatementClosed);
+        }
+
+        // Validate session state
+        self.session
+            .validate_ready()
+            .await
+            .map_err(|e| QueryError::InvalidState(e.to_string()))?;
+
+        // Update session state
+        self.session.set_state(SessionState::Executing).await;
+
+        // Convert batch parameters to column-major JSON format
+        let params_data = stmt.build_batch_parameters_data(rows)?;
+
+        let mut transport = self.transport.lock().await;
+        let result = transport
+            .execute_prepared_statement(stmt.handle_ref(), params_data)
+            .await
+            .map_err(|e| QueryError::ExecutionFailed(e.to_string()))?;
+
+        drop(transport);
+
+        // Update session state back to ready/in_transaction
+        self.update_session_state_after_query().await;
+
+        match result {
+            QueryResult::RowCount { count } => Ok(count),
+            QueryResult::ResultSet { .. } => Err(QueryError::UnexpectedResultSet),
+        }
+    }
+
+    /// Execute a prepared statement with multiple rows of parameters and return a result set.
+    ///
+    /// Use this for batch SELECT statements or queries that return rows.
+    ///
+    /// # Arguments
+    ///
+    /// * `stmt` - Prepared statement to execute
+    /// * `rows` - Slice of parameter rows; each row is a `Vec<Parameter>` in positional order
+    ///
+    /// # Returns
+    ///
+    /// A `ResultSet` containing the query results.
+    ///
+    /// # Errors
+    ///
+    /// Returns `QueryError` if execution fails or if the statement is closed.
+    pub async fn execute_batch(
+        &mut self,
+        stmt: &PreparedStatement,
+        rows: &[Vec<Parameter>],
+    ) -> Result<ResultSet, QueryError> {
+        if stmt.is_closed() {
+            return Err(QueryError::StatementClosed);
+        }
+
+        // Validate session state
+        self.session
+            .validate_ready()
+            .await
+            .map_err(|e| QueryError::InvalidState(e.to_string()))?;
+
+        // Update session state
+        self.session.set_state(SessionState::Executing).await;
+
+        // Increment query counter
+        self.session.increment_query_count();
+
+        // Convert batch parameters to column-major JSON format
+        let params_data = stmt.build_batch_parameters_data(rows)?;
+
+        let mut transport = self.transport.lock().await;
+        let result = transport
+            .execute_prepared_statement(stmt.handle_ref(), params_data)
+            .await
+            .map_err(|e| QueryError::ExecutionFailed(e.to_string()))?;
+
+        drop(transport);
+
+        // Update session state back to ready/in_transaction
+        self.update_session_state_after_query().await;
+
+        ResultSet::from_transport_result(result, Arc::clone(&self.transport))
     }
 
     /// Close a prepared statement and release server-side resources.

--- a/src/query/prepared.rs
+++ b/src/query/prepared.rs
@@ -60,8 +60,11 @@ impl PreparedStatement {
         self.closed
     }
 
-    /// Mark the prepared statement as closed (called by Connection).
-    pub(crate) fn mark_closed(&mut self) {
+    /// Mark this statement closed so it cannot be reused.
+    ///
+    /// Call this after an external resource (e.g. a server-side handle) has already
+    /// been released, so the statement reflects the closed state without a network round-trip.
+    pub fn mark_closed(&mut self) {
         self.closed = true;
     }
 
@@ -98,6 +101,43 @@ impl PreparedStatement {
     /// Get bound parameters.
     pub fn parameters(&self) -> &[Option<Parameter>] {
         &self.parameters
+    }
+
+    /// Build batch parameters data in column-major format for multi-row execution.
+    ///
+    /// Accepts row-major input (`rows[r][c]`) and transposes it into the column-major
+    /// wire format (`columns[c][r]`) expected by the transport layer.
+    ///
+    /// Returns `Ok(None)` for an empty batch (mirrors the 0-parameter case).
+    /// Returns `Err(ParameterBindingError)` if any row's length differs from `parameter_count()`.
+    pub fn build_batch_parameters_data(
+        &self,
+        rows: &[Vec<Parameter>],
+    ) -> Result<Option<Vec<Vec<serde_json::Value>>>, QueryError> {
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        let expected = self.parameter_count();
+        for (i, row) in rows.iter().enumerate() {
+            if row.len() != expected {
+                return Err(QueryError::ParameterBindingError {
+                    index: i,
+                    message: format!(
+                        "Row {} has {} parameters but statement expects {}",
+                        i,
+                        row.len(),
+                        expected
+                    ),
+                });
+            }
+        }
+
+        let columns: Vec<Vec<serde_json::Value>> = (0..expected)
+            .map(|c| rows.iter().map(|row| parameter_to_json(&row[c])).collect())
+            .collect();
+
+        Ok(Some(columns))
     }
 
     /// Build parameters data in column-major format for the protocol.
@@ -368,6 +408,102 @@ mod tests {
         assert_eq!(
             parameter_to_json(&Parameter::Binary(vec![0x00, 0xFF])),
             serde_json::json!("00ff")
+        );
+    }
+
+    #[test]
+    fn test_build_batch_params_empty() {
+        let handle = PreparedStatementHandle::new(1, 2, vec![], vec![]);
+        let stmt = PreparedStatement::new(handle);
+
+        let result = stmt.build_batch_parameters_data(&[]);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_build_batch_params_arity_mismatch() {
+        let handle = PreparedStatementHandle::new(1, 2, vec![], vec![]);
+        let stmt = PreparedStatement::new(handle);
+
+        // Row 0 has 2 params (ok), row 1 has only 1 param (mismatch at index 1)
+        let rows = vec![
+            vec![Parameter::Integer(1), Parameter::Integer(2)],
+            vec![Parameter::Integer(3)],
+        ];
+        let result = stmt.build_batch_parameters_data(&rows);
+        assert!(matches!(
+            result.unwrap_err(),
+            QueryError::ParameterBindingError { index: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn test_build_batch_params_column_major() {
+        let handle = PreparedStatementHandle::new(1, 2, vec![], vec![]);
+        let stmt = PreparedStatement::new(handle);
+
+        let rows = vec![
+            vec![Parameter::Integer(10), Parameter::Integer(20)],
+            vec![Parameter::Integer(30), Parameter::Integer(40)],
+            vec![Parameter::Integer(50), Parameter::Integer(60)],
+        ];
+        let columns = stmt.build_batch_parameters_data(&rows).unwrap().unwrap();
+
+        // Column 0 should be [10, 30, 50], column 1 should be [20, 40, 60]
+        assert_eq!(columns.len(), 2);
+        assert_eq!(
+            columns[0],
+            vec![
+                serde_json::json!(10),
+                serde_json::json!(30),
+                serde_json::json!(50)
+            ]
+        );
+        assert_eq!(
+            columns[1],
+            vec![
+                serde_json::json!(20),
+                serde_json::json!(40),
+                serde_json::json!(60)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_batch_params_binary_hex() {
+        let handle = PreparedStatementHandle::new(1, 1, vec![], vec![]);
+        let stmt = PreparedStatement::new(handle);
+
+        let rows = vec![
+            vec![Parameter::Binary(vec![0xDE, 0xAD])],
+            vec![Parameter::Binary(vec![0xBE, 0xEF])],
+        ];
+        let columns = stmt.build_batch_parameters_data(&rows).unwrap().unwrap();
+
+        assert_eq!(columns.len(), 1);
+        assert_eq!(
+            columns[0],
+            vec![serde_json::json!("dead"), serde_json::json!("beef")]
+        );
+    }
+
+    #[test]
+    fn test_build_batch_params_mixed_types() {
+        let handle = PreparedStatementHandle::new(1, 2, vec![], vec![]);
+        let stmt = PreparedStatement::new(handle);
+
+        let rows = vec![
+            vec![Parameter::Integer(1), Parameter::Binary(vec![0xAB])],
+            vec![Parameter::Integer(2), Parameter::Binary(vec![0xCD])],
+        ];
+        let columns = stmt.build_batch_parameters_data(&rows).unwrap().unwrap();
+
+        assert_eq!(columns.len(), 2);
+        assert_eq!(columns[0], vec![serde_json::json!(1), serde_json::json!(2)]);
+        assert_eq!(
+            columns[1],
+            vec![serde_json::json!("ab"), serde_json::json!("cd")]
         );
     }
 }

--- a/src/transport/native/mod.rs
+++ b/src/transport/native/mod.rs
@@ -399,16 +399,29 @@ impl NativeTcpTransport {
                 }
             }
 
-            // Write column data (column-major: for each column, for each row)
-            for (i, col_values) in cols.iter().enumerate() {
-                let (wire_type, _) = Self::infer_wire_type(handle, i, col_values);
-                let scale = if wire_type == T_DECIMAL {
-                    Self::decimal_metadata(handle, i).1
-                } else {
-                    0
-                };
-                for value in col_values {
-                    Self::write_param_value(&mut buf, wire_type, value, scale)?;
+            // Write parameter data in row-major order: col0_row0, col1_row0, col0_row1, ...
+            // Exasol's native prepared-statement protocol requires this interleaving.
+            // Column-major encoding causes the server to drop the connection for num_rows > 1;
+            // the two orderings coincide for num_rows = 1, which is why single-row execution
+            // was unaffected before this fix.
+            let wire_types_and_scales: Vec<(u32, i32)> = cols
+                .iter()
+                .enumerate()
+                .map(|(i, col_values)| {
+                    let (wire_type, _) = Self::infer_wire_type(handle, i, col_values);
+                    let scale = if wire_type == T_DECIMAL {
+                        Self::decimal_metadata(handle, i).1
+                    } else {
+                        0
+                    };
+                    (wire_type, scale)
+                })
+                .collect();
+
+            for row_idx in 0..num_rows {
+                for (col_idx, col_values) in cols.iter().enumerate() {
+                    let (wire_type, scale) = wire_types_and_scales[col_idx];
+                    Self::write_param_value(&mut buf, wire_type, &col_values[row_idx], scale)?;
                 }
             }
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -78,6 +78,7 @@ use common::{
     get_user, is_exasol_available,
 };
 use exarrow_rs::adbc::Connection;
+use exarrow_rs::{Parameter, QueryError};
 
 // Infrastructure Tests
 // These tests validate that the test infrastructure itself works correctly.
@@ -2670,4 +2671,261 @@ fn test_arrow_parquet_resolve_to_58_or_above_with_unified_sub_crates() {
         arrow_array_57_count, 0,
         "arrow-array must not appear at a 57.x version alongside 58.x"
     );
+}
+
+// Section 11: Batch Prepared Statement Integration Tests
+//
+// These tests verify multi-row (batch) prepared statement execution via
+// `Connection::execute_batch_update` and `Connection::execute_batch`.
+
+/// 11.1 Batch INSERT: execute several rows in one call and verify the affected-row count
+/// and the actual rows stored in the table.
+#[tokio::test]
+async fn test_execute_batch_update() {
+    skip_if_no_exasol!();
+
+    let mut conn = get_test_connection().await.expect("Failed to connect");
+
+    let schema_name = generate_test_schema_name();
+
+    conn.execute_update(&format!("CREATE SCHEMA {}", schema_name))
+        .await
+        .expect("CREATE SCHEMA should succeed");
+
+    conn.execute_update(&format!(
+        "CREATE TABLE {}.batch_test (id INTEGER, name VARCHAR(100))",
+        schema_name
+    ))
+    .await
+    .expect("CREATE TABLE should succeed");
+
+    let prepared = conn
+        .prepare(&format!(
+            "INSERT INTO {}.batch_test VALUES (?, ?)",
+            schema_name
+        ))
+        .await
+        .expect("Failed to prepare INSERT");
+
+    assert_eq!(prepared.parameter_count(), 2);
+
+    let rows: Vec<Vec<Parameter>> = vec![
+        vec![
+            Parameter::Integer(1),
+            Parameter::String("Alice".to_string()),
+        ],
+        vec![Parameter::Integer(2), Parameter::String("Bob".to_string())],
+        vec![
+            Parameter::Integer(3),
+            Parameter::String("Charlie".to_string()),
+        ],
+    ];
+
+    let affected = conn
+        .execute_batch_update(&prepared, &rows)
+        .await
+        .expect("execute_batch_update should succeed");
+
+    assert_eq!(
+        affected, 3,
+        "Affected row count should equal the number of batch rows"
+    );
+
+    conn.close_prepared(prepared)
+        .await
+        .expect("Failed to close prepared statement");
+
+    // Verify all rows were inserted
+    let batches = conn
+        .query(&format!(
+            "SELECT id, name FROM {}.batch_test ORDER BY id",
+            schema_name
+        ))
+        .await
+        .expect("SELECT should succeed");
+
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 3, "All 3 batch rows should be present");
+
+    let batch = &batches[0];
+    let name_col = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("name column should be StringArray");
+
+    assert_eq!(name_col.value(0), "Alice");
+    assert_eq!(name_col.value(1), "Bob");
+    assert_eq!(name_col.value(2), "Charlie");
+
+    cleanup_schema(&mut conn, &schema_name).await;
+    conn.close().await.expect("Failed to close connection");
+}
+
+/// 11.2 Batch SELECT: execute a prepared SELECT with a single-row parameter batch and
+/// verify the result set is returned correctly via `execute_batch`.
+///
+/// Note: exercises the `execute_batch` code path with a single-row batch; multi-row
+/// SELECT parameter semantics are out of scope for this test.
+#[tokio::test]
+async fn test_execute_batch_select_single_row() {
+    skip_if_no_exasol!();
+
+    let mut conn = get_test_connection().await.expect("Failed to connect");
+
+    let schema_name = generate_test_schema_name();
+
+    conn.execute_update(&format!("CREATE SCHEMA {}", schema_name))
+        .await
+        .expect("CREATE SCHEMA should succeed");
+
+    conn.execute_update(&format!(
+        "CREATE TABLE {}.batch_sel (id INTEGER, label VARCHAR(50))",
+        schema_name
+    ))
+    .await
+    .expect("CREATE TABLE should succeed");
+
+    conn.execute_update(&format!(
+        "INSERT INTO {}.batch_sel VALUES (1, 'one'), (2, 'two'), (3, 'three')",
+        schema_name
+    ))
+    .await
+    .expect("INSERT should succeed");
+
+    // Prepare a SELECT with one parameter (filter by id)
+    let prepared = conn
+        .prepare(&format!(
+            "SELECT id, label FROM {}.batch_sel WHERE id = ?",
+            schema_name
+        ))
+        .await
+        .expect("Failed to prepare SELECT");
+
+    assert_eq!(prepared.parameter_count(), 1);
+
+    // Execute with a single-row parameter batch: fetch the row where id = 2
+    let rows: Vec<Vec<Parameter>> = vec![vec![Parameter::Integer(2)]];
+
+    let result_set = conn
+        .execute_batch(&prepared, &rows)
+        .await
+        .expect("execute_batch should succeed");
+
+    let batches = result_set
+        .fetch_all()
+        .await
+        .expect("Failed to fetch result set");
+
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 1, "Should return 1 row for id = 2");
+
+    let label_col = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("label column should be StringArray");
+
+    assert_eq!(
+        label_col.value(0),
+        "two",
+        "Row with id=2 should have label 'two'"
+    );
+
+    conn.close_prepared(prepared)
+        .await
+        .expect("Failed to close prepared statement");
+
+    cleanup_schema(&mut conn, &schema_name).await;
+    conn.close().await.expect("Failed to close connection");
+}
+
+/// 11.3 Batch execution on a closed prepared statement must return `QueryError::StatementClosed`.
+#[tokio::test]
+async fn test_execute_batch_closed_statement() {
+    skip_if_no_exasol!();
+
+    let mut conn = get_test_connection().await.expect("Failed to connect");
+
+    let mut prepared = conn
+        .prepare("SELECT 1")
+        .await
+        .expect("Failed to prepare statement");
+
+    assert!(!prepared.is_closed());
+
+    // Mark the statement closed directly so we can still hold the binding and test both
+    // batch methods on the same closed statement.
+    prepared.mark_closed();
+
+    assert!(prepared.is_closed());
+
+    // Both batch methods must reject with StatementClosed
+    let rows: Vec<Vec<Parameter>> = vec![];
+
+    let update_err = conn
+        .execute_batch_update(&prepared, &rows)
+        .await
+        .expect_err("execute_batch_update on a closed statement must fail");
+
+    assert!(
+        matches!(update_err, QueryError::StatementClosed),
+        "Expected StatementClosed, got: {:?}",
+        update_err
+    );
+
+    let select_err = conn
+        .execute_batch(&prepared, &rows)
+        .await
+        .expect_err("execute_batch on a closed statement must fail");
+
+    assert!(
+        matches!(select_err, QueryError::StatementClosed),
+        "Expected StatementClosed, got: {:?}",
+        select_err
+    );
+
+    // Release the server-side handle since we bypassed close_prepared above.
+    conn.close_prepared(prepared)
+        .await
+        .expect("Failed to close prepared statement");
+
+    conn.close().await.expect("Failed to close connection");
+}
+
+/// 11.4 `execute_batch_update` against a prepared SELECT (which returns a result set)
+/// must return `QueryError::UnexpectedResultSet`.
+#[tokio::test]
+async fn test_execute_batch_update_rejects_result_set() {
+    skip_if_no_exasol!();
+
+    let mut conn = get_test_connection().await.expect("Failed to connect");
+
+    // Prepare a SELECT — it returns a result set, not an affected-row count
+    let prepared = conn
+        .prepare("SELECT 42 AS answer")
+        .await
+        .expect("Failed to prepare SELECT");
+
+    assert_eq!(prepared.parameter_count(), 0);
+
+    // Empty batch: no rows, no params — execute_batch_update must reject the result set response
+    let rows: Vec<Vec<Parameter>> = vec![];
+
+    let err = conn
+        .execute_batch_update(&prepared, &rows)
+        .await
+        .expect_err("execute_batch_update on a SELECT should fail with UnexpectedResultSet");
+
+    assert!(
+        matches!(err, QueryError::UnexpectedResultSet),
+        "Expected UnexpectedResultSet, got: {:?}",
+        err
+    );
+
+    conn.close_prepared(prepared)
+        .await
+        .expect("Failed to close prepared statement");
+
+    conn.close().await.expect("Failed to close connection");
 }


### PR DESCRIPTION
## Summary

Adds multi-row (batch) prepared-statement execution to the public API. Pure additive surface — backward-compatible patch release **v0.12.8**, no breaking changes.

- `PreparedStatement::build_batch_parameters_data(&self, rows: &[Vec<Parameter>])` — transposes row-major input into column-major wire data; fail-fast per-row arity check before any transport call; empty batch → `Ok(None)`.
- `Connection::execute_batch_update(&mut self, stmt, rows) -> Result<i64, _>` — affected row count.
- `Connection::execute_batch(&mut self, stmt, rows) -> Result<ResultSet, _>` — result set.
- `PreparedStatement::mark_closed` widened `pub(crate)` → `pub` (additive) so a statement can be invalidated without a server round-trip.

## Latent transport bug fixed (please review closely)

Implementing the batch path surfaced a real bug in `src/transport/native/mod.rs::build_execute_prepared_payload`: multi-row parameter data was encoded **column-major**, but the Exasol native protocol requires **row-major interleaving**. The server drops the connection for `num_rows > 1`. This was invisible until now because single-row execution — the only prior caller — is byte-identical in both orderings. Fixed to row-major; single-row confirmed unregressed by the full integration suite.

The plan's original non-goal was "no transport changes"; this fix is a necessary deviation, documented in the verification report.

## Verification (against local Exasol Docker)

| Suite | Result |
|-------|--------|
| Unit (`--lib`) | 1029 passed, 0 failed |
| Integration | 62 passed, 0 failed |
| E2E driver-manager | 40 passed, 0 failed |
| E2E import/export | 42 passed, 0 failed |
| clippy / fmt | 0 warnings / clean |

## Specs

- New feature `prepared-statements/batch-execution` (7 scenarios) — split out from `binding-and-execution` to stay under the per-feature scenario threshold.
- ADR-008: fail-fast per-row arity check before any transport call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)