### PR TITLE
refactor: ponytail audit — remove dead code, de-duplicate TLS/CSV paths

### DIFF
--- a/examples/prepared_statements.rs
+++ b/examples/prepared_statements.rs
@@ -31,7 +31,10 @@ async fn example_connection() -> Result<Connection, Box<dyn Error>> {
 /// Inserts one row with a single-row prepared statement, binding by index.
 async fn example_single_row(conn: &mut Connection) -> Result<i64, Box<dyn Error>> {
     let mut stmt = conn
-        .prepare(&format!("INSERT INTO {}.prep_example VALUES (?, ?)", SCHEMA))
+        .prepare(&format!(
+            "INSERT INTO {}.prep_example VALUES (?, ?)",
+            SCHEMA
+        ))
         .await?;
     stmt.bind(0, 1)?;
     stmt.bind(1, "Alice")?;
@@ -43,13 +46,19 @@ async fn example_single_row(conn: &mut Connection) -> Result<i64, Box<dyn Error>
 /// Inserts several rows in one batch call and returns the affected-row count.
 async fn example_batch_insert(conn: &mut Connection) -> Result<i64, Box<dyn Error>> {
     let prepared = conn
-        .prepare(&format!("INSERT INTO {}.prep_example VALUES (?, ?)", SCHEMA))
+        .prepare(&format!(
+            "INSERT INTO {}.prep_example VALUES (?, ?)",
+            SCHEMA
+        ))
         .await?;
 
     // Each inner Vec is one row's parameters, in positional order.
     let rows: Vec<Vec<Parameter>> = vec![
         vec![Parameter::Integer(2), Parameter::String("Bob".to_string())],
-        vec![Parameter::Integer(3), Parameter::String("Charlie".to_string())],
+        vec![
+            Parameter::Integer(3),
+            Parameter::String("Charlie".to_string()),
+        ],
     ];
 
     let affected = conn.execute_batch_update(&prepared, &rows).await?;

--- a/src/connection/session.rs
+++ b/src/connection/session.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles session lifecycle, state tracking, and connection pooling support.
 
-use crate::connection::auth::{AuthResponseData, AuthenticationHandler};
+use crate::connection::auth::AuthResponseData;
 use crate::connection::version::parse_release_version;
 use crate::error::ConnectionError;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -124,9 +124,6 @@ pub struct Session {
     /// Current schema
     current_schema: Arc<RwLock<Option<String>>>,
 
-    /// Session attributes
-    attributes: Arc<RwLock<std::collections::HashMap<String, String>>>,
-
     /// Memoized native-Parquet-import capability, derived from `server_info.release_version`.
     native_parquet_cache: OnceLock<bool>,
 }
@@ -143,7 +140,6 @@ impl Session {
             query_count: AtomicU64::new(0),
             in_transaction: AtomicBool::new(false),
             current_schema: Arc::new(RwLock::new(None)),
-            attributes: Arc::new(RwLock::new(std::collections::HashMap::new())),
             native_parquet_cache: OnceLock::new(),
         }
     }
@@ -190,17 +186,6 @@ impl Session {
     pub async fn update_activity(&self) {
         let mut last_activity = self.last_activity.write().await;
         *last_activity = Instant::now();
-    }
-
-    /// Get time since last activity.
-    pub async fn idle_duration(&self) -> Duration {
-        let last_activity = self.last_activity.read().await;
-        last_activity.elapsed()
-    }
-
-    /// Check if session is idle beyond timeout.
-    pub async fn is_idle_timeout(&self) -> bool {
-        self.idle_duration().await > self.config.idle_timeout
     }
 
     /// Increment query counter.
@@ -277,24 +262,6 @@ impl Session {
         self.update_activity().await;
     }
 
-    /// Get a session attribute.
-    pub async fn get_attribute(&self, key: &str) -> Option<String> {
-        let attributes = self.attributes.read().await;
-        attributes.get(key).cloned()
-    }
-
-    /// Set a session attribute.
-    pub async fn set_attribute(&self, key: String, value: String) {
-        let mut attributes = self.attributes.write().await;
-        attributes.insert(key, value);
-    }
-
-    /// Remove a session attribute.
-    pub async fn remove_attribute(&self, key: &str) -> Option<String> {
-        let mut attributes = self.attributes.write().await;
-        attributes.remove(key)
-    }
-
     /// Close the session.
     pub async fn close(&self) -> Result<(), ConnectionError> {
         self.set_state(SessionState::Closing).await;
@@ -313,11 +280,6 @@ impl Session {
     /// Check if session is closed.
     pub async fn is_closed(&self) -> bool {
         matches!(self.state().await, SessionState::Closed)
-    }
-
-    /// Mark session as having an error.
-    pub async fn mark_error(&self) {
-        self.set_state(SessionState::Error).await;
     }
 
     /// Validate session is ready for operations.
@@ -351,103 +313,10 @@ impl std::fmt::Debug for Session {
     }
 }
 
-/// Session manager for connection pooling and lifecycle management.
-pub struct SessionManager {
-    /// Active sessions
-    sessions: Arc<RwLock<std::collections::HashMap<String, Arc<Session>>>>,
-
-    /// Session factory (authentication handler)
-    _auth_handler: Arc<AuthenticationHandler>,
-
-    /// Session configuration
-    config: SessionConfig,
-}
-
-impl SessionManager {
-    /// Create a new session manager.
-    pub fn new(auth_handler: Arc<AuthenticationHandler>, config: SessionConfig) -> Self {
-        Self {
-            sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            _auth_handler: auth_handler,
-            config,
-        }
-    }
-
-    /// Register a new session.
-    pub async fn register_session(&self, session: Arc<Session>) {
-        let mut sessions = self.sessions.write().await;
-        sessions.insert(session.session_id().to_string(), session);
-    }
-
-    /// Get a session by ID.
-    pub async fn get_session(&self, session_id: &str) -> Option<Arc<Session>> {
-        let sessions = self.sessions.read().await;
-        sessions.get(session_id).cloned()
-    }
-
-    /// Remove a session.
-    pub async fn remove_session(&self, session_id: &str) -> Option<Arc<Session>> {
-        let mut sessions = self.sessions.write().await;
-        sessions.remove(session_id)
-    }
-
-    /// Get all active sessions.
-    pub async fn active_sessions(&self) -> Vec<Arc<Session>> {
-        let sessions = self.sessions.read().await;
-        sessions.values().cloned().collect()
-    }
-
-    /// Close all sessions.
-    pub async fn close_all(&self) -> Result<(), ConnectionError> {
-        let sessions = {
-            let mut sessions = self.sessions.write().await;
-            let active: Vec<_> = sessions.drain().map(|(_, s)| s).collect();
-            active
-        };
-
-        for session in sessions {
-            session.close().await?;
-        }
-
-        Ok(())
-    }
-
-    /// Clean up idle sessions beyond timeout.
-    pub async fn cleanup_idle_sessions(&self) -> usize {
-        let sessions = self.sessions.read().await;
-        let mut to_remove = Vec::new();
-
-        for (id, session) in sessions.iter() {
-            if session.is_idle_timeout().await {
-                to_remove.push(id.clone());
-            }
-        }
-
-        drop(sessions);
-
-        let count = to_remove.len();
-        for id in to_remove {
-            if let Some(session) = self.remove_session(&id).await {
-                let _ = session.close().await;
-            }
-        }
-
-        count
-    }
-}
-
-impl std::fmt::Debug for SessionManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SessionManager")
-            .field("config", &self.config)
-            .finish()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::connection::auth::{AuthResponseData, Credentials};
+    use crate::connection::auth::AuthResponseData;
 
     fn mock_server_info() -> AuthResponseData {
         mock_server_info_with_version("7.1.0")
@@ -608,47 +477,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_session_attributes() {
-        let session = Session::new(
-            "sess123".to_string(),
-            mock_server_info(),
-            SessionConfig::default(),
-        );
-
-        assert!(session.get_attribute("key1").await.is_none());
-
-        session
-            .set_attribute("key1".to_string(), "value1".to_string())
-            .await;
-        assert_eq!(
-            session.get_attribute("key1").await,
-            Some("value1".to_string())
-        );
-
-        let removed = session.remove_attribute("key1").await;
-        assert_eq!(removed, Some("value1".to_string()));
-        assert!(session.get_attribute("key1").await.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_session_activity() {
-        let session = Session::new(
-            "sess123".to_string(),
-            mock_server_info(),
-            SessionConfig::default(),
-        );
-
-        session.update_activity().await;
-
-        let idle = session.idle_duration().await;
-        assert!(idle < Duration::from_millis(100));
-
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        let idle = session.idle_duration().await;
-        assert!(idle >= Duration::from_millis(10));
-    }
-
-    #[tokio::test]
     async fn test_session_close() {
         let session = Session::new(
             "sess123".to_string(),
@@ -681,69 +509,6 @@ mod tests {
         // Error state should fail
         session.set_state(SessionState::Error).await;
         assert!(session.validate_ready().await.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_session_manager() {
-        let creds = Credentials::new("admin".to_string(), "secret".to_string());
-        let auth_handler = Arc::new(AuthenticationHandler::new(
-            creds,
-            "test".to_string(),
-            "1.0".to_string(),
-        ));
-        let manager = SessionManager::new(auth_handler, SessionConfig::default());
-
-        let session = Arc::new(Session::new(
-            "sess123".to_string(),
-            mock_server_info(),
-            SessionConfig::default(),
-        ));
-
-        // Register session
-        manager.register_session(session.clone()).await;
-
-        // Get session
-        let retrieved = manager.get_session("sess123").await;
-        assert!(retrieved.is_some());
-        assert_eq!(retrieved.unwrap().session_id(), "sess123");
-
-        // Active sessions
-        let active = manager.active_sessions().await;
-        assert_eq!(active.len(), 1);
-
-        // Remove session
-        let removed = manager.remove_session("sess123").await;
-        assert!(removed.is_some());
-
-        // Session no longer found
-        assert!(manager.get_session("sess123").await.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_session_manager_close_all() {
-        let creds = Credentials::new("admin".to_string(), "secret".to_string());
-        let auth_handler = Arc::new(AuthenticationHandler::new(
-            creds,
-            "test".to_string(),
-            "1.0".to_string(),
-        ));
-        let manager = SessionManager::new(auth_handler, SessionConfig::default());
-
-        // Register multiple sessions
-        for i in 0..3 {
-            let session = Arc::new(Session::new(
-                format!("sess{}", i),
-                mock_server_info(),
-                SessionConfig::default(),
-            ));
-            manager.register_session(session).await;
-        }
-
-        assert_eq!(manager.active_sessions().await.len(), 3);
-
-        // Close all
-        manager.close_all().await.unwrap();
-        assert_eq!(manager.active_sessions().await.len(), 0);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,6 @@
 //!
 //! This module defines domain-specific error types organized by functional area.
 
-use std::fmt;
 use thiserror::Error;
 
 /// Top-level error type encompassing all possible errors.
@@ -181,77 +180,6 @@ pub enum TransportError {
     TlsError(String),
 }
 
-/// ADBC-compatible error codes.
-///
-/// These codes map to the ADBC specification for driver interoperability.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AdbcErrorCode {
-    /// Unknown error
-    Unknown = 0,
-    /// Connection error
-    Connection = 1,
-    /// Query error
-    Query = 2,
-    /// Invalid argument
-    InvalidArgument = 3,
-    /// Invalid state
-    InvalidState = 4,
-    /// Not implemented
-    NotImplemented = 5,
-    /// Timeout
-    Timeout = 6,
-}
-
-impl fmt::Display for AdbcErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AdbcErrorCode::Unknown => write!(f, "UNKNOWN"),
-            AdbcErrorCode::Connection => write!(f, "CONNECTION"),
-            AdbcErrorCode::Query => write!(f, "QUERY"),
-            AdbcErrorCode::InvalidArgument => write!(f, "INVALID_ARGUMENT"),
-            AdbcErrorCode::InvalidState => write!(f, "INVALID_STATE"),
-            AdbcErrorCode::NotImplemented => write!(f, "NOT_IMPLEMENTED"),
-            AdbcErrorCode::Timeout => write!(f, "TIMEOUT"),
-        }
-    }
-}
-
-impl ExasolError {
-    /// Map to ADBC error code.
-    pub fn to_adbc_code(&self) -> AdbcErrorCode {
-        match self {
-            ExasolError::Connection(e) => e.to_adbc_code(),
-            ExasolError::Query(e) => e.to_adbc_code(),
-            ExasolError::Conversion(_) => AdbcErrorCode::Query,
-            ExasolError::Transport(_) => AdbcErrorCode::Connection,
-        }
-    }
-}
-
-impl ConnectionError {
-    /// Map to ADBC error code.
-    pub fn to_adbc_code(&self) -> AdbcErrorCode {
-        match self {
-            ConnectionError::Timeout { .. } => AdbcErrorCode::Timeout,
-            ConnectionError::InvalidParameter { .. } => AdbcErrorCode::InvalidArgument,
-            _ => AdbcErrorCode::Connection,
-        }
-    }
-}
-
-impl QueryError {
-    /// Map to ADBC error code.
-    pub fn to_adbc_code(&self) -> AdbcErrorCode {
-        match self {
-            QueryError::Timeout { .. } => AdbcErrorCode::Timeout,
-            QueryError::InvalidState(_) => AdbcErrorCode::InvalidState,
-            QueryError::ParameterBindingError { .. } => AdbcErrorCode::InvalidArgument,
-            QueryError::StatementClosed => AdbcErrorCode::InvalidState,
-            _ => AdbcErrorCode::Query,
-        }
-    }
-}
-
 // Conversions from external error types
 impl From<arrow::error::ArrowError> for ConversionError {
     fn from(err: arrow::error::ArrowError) -> Self {
@@ -308,21 +236,6 @@ mod tests {
     }
 
     #[test]
-    fn test_adbc_error_code_mapping() {
-        let err = ExasolError::Connection(ConnectionError::Timeout { timeout_ms: 5000 });
-        assert_eq!(err.to_adbc_code(), AdbcErrorCode::Timeout);
-
-        let err = ExasolError::Query(QueryError::InvalidState("Bad state".to_string()));
-        assert_eq!(err.to_adbc_code(), AdbcErrorCode::InvalidState);
-    }
-
-    #[test]
-    fn test_error_code_display() {
-        assert_eq!(AdbcErrorCode::Connection.to_string(), "CONNECTION");
-        assert_eq!(AdbcErrorCode::Timeout.to_string(), "TIMEOUT");
-    }
-
-    #[test]
     fn test_transport_tls_error() {
         let err = TransportError::TlsError("Certificate validation failed".to_string());
         assert!(err.to_string().contains("TLS error"));
@@ -333,7 +246,6 @@ mod tests {
     fn test_statement_closed_error() {
         let err = QueryError::StatementClosed;
         assert!(err.to_string().contains("closed"));
-        assert_eq!(err.to_adbc_code(), AdbcErrorCode::InvalidState);
     }
 
     #[test]

--- a/src/export/arrow.rs
+++ b/src/export/arrow.rs
@@ -33,7 +33,7 @@ use arrow::array::builder::{
     TimestampMicrosecondBuilder,
 };
 use arrow::array::{ArrayRef, RecordBatch};
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::datatypes::{DataType, Schema, TimeUnit};
 use thiserror::Error;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
@@ -294,12 +294,17 @@ impl<R: AsyncBufRead + Unpin> CsvToArrowReader<R> {
                 continue;
             }
 
-            let fields = parse_csv_row(
+            let (fields, in_quotes) = crate::export::csv::parse_csv_row(
                 line,
                 self.column_separator,
                 self.column_delimiter,
-                self.current_row,
-            )?;
+            );
+            if in_quotes {
+                return Err(ExportError::CsvParseError {
+                    row: self.current_row,
+                    message: "Unclosed quote in CSV row".to_string(),
+                });
+            }
             rows.push(fields);
             self.current_row += 1;
         }
@@ -343,55 +348,6 @@ impl<R: AsyncBufRead + Unpin> CsvToArrowReader<R> {
         RecordBatch::try_new(Arc::clone(&self.schema), arrays)
             .map_err(|e| ExportError::ArrowError(e.to_string()))
     }
-}
-
-/// Parses a CSV row into fields, handling quoted values.
-fn parse_csv_row(
-    line: &str,
-    separator: char,
-    delimiter: char,
-    row: usize,
-) -> Result<Vec<String>, ExportError> {
-    let mut fields = Vec::new();
-    let mut current_field = String::new();
-    let mut in_quotes = false;
-    let mut chars = line.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        if in_quotes {
-            if c == delimiter {
-                // Check for escaped quote (double delimiter)
-                if chars.peek() == Some(&delimiter) {
-                    current_field.push(delimiter);
-                    chars.next();
-                } else {
-                    in_quotes = false;
-                }
-            } else {
-                current_field.push(c);
-            }
-        } else if c == delimiter {
-            in_quotes = true;
-        } else if c == separator {
-            fields.push(current_field);
-            current_field = String::new();
-        } else {
-            current_field.push(c);
-        }
-    }
-
-    // Don't forget the last field
-    fields.push(current_field);
-
-    // Validate that we're not still in quotes
-    if in_quotes {
-        return Err(ExportError::CsvParseError {
-            row,
-            message: "Unclosed quote in CSV row".to_string(),
-        });
-    }
-
-    Ok(fields)
 }
 
 /// Builds an Arrow array from string values.
@@ -690,80 +646,6 @@ pub fn exasol_type_to_arrow(exasol_type: &ExasolType) -> Result<DataType, Export
     exasol_type_to_arrow_impl(exasol_type).map_err(ExportError::SchemaError)
 }
 
-/// Builds an Arrow schema from Exasol column metadata.
-pub fn build_schema_from_exasol_types(
-    columns: &[(String, ExasolType, bool)],
-) -> Result<Schema, ExportError> {
-    let fields: Result<Vec<Field>, ExportError> = columns
-        .iter()
-        .map(|(name, exasol_type, nullable)| {
-            let data_type = exasol_type_to_arrow(exasol_type)?;
-            Ok(Field::new(name, data_type, *nullable))
-        })
-        .collect();
-
-    Ok(Schema::new(fields?))
-}
-
-/// Writes Arrow RecordBatches to Arrow IPC format.
-///
-/// # Arguments
-///
-/// * `writer` - The async writer to write to
-/// * `schema` - The Arrow schema
-/// * `batches` - Iterator of RecordBatches to write
-///
-/// # Returns
-///
-/// The total number of rows written.
-pub async fn write_arrow_ipc<W, I>(
-    writer: &mut W,
-    schema: Arc<Schema>,
-    batches: I,
-) -> Result<u64, ExportError>
-where
-    W: AsyncWrite + Unpin + Send,
-    I: IntoIterator<Item = Result<RecordBatch, ExportError>>,
-{
-    use arrow::ipc::writer::StreamWriter;
-    use std::io::Cursor;
-
-    let mut total_rows = 0u64;
-
-    // We need to use synchronous Arrow IPC writer, then write to async
-    // First, collect all batches and write to a buffer
-    let mut buffer = Cursor::new(Vec::new());
-    {
-        let mut ipc_writer = StreamWriter::try_new(&mut buffer, &schema)
-            .map_err(|e| ExportError::ArrowError(e.to_string()))?;
-
-        for batch_result in batches {
-            let batch = batch_result?;
-            total_rows += batch.num_rows() as u64;
-            ipc_writer
-                .write(&batch)
-                .map_err(|e| ExportError::ArrowError(e.to_string()))?;
-        }
-
-        ipc_writer
-            .finish()
-            .map_err(|e| ExportError::ArrowError(e.to_string()))?;
-    }
-
-    // Write the buffer to the async writer
-    let data = buffer.into_inner();
-    writer
-        .write_all(&data)
-        .await
-        .map_err(|e| ExportError::IoError(e.to_string()))?;
-    writer
-        .flush()
-        .await
-        .map_err(|e| ExportError::IoError(e.to_string()))?;
-
-    Ok(total_rows)
-}
-
 /// Writes Arrow RecordBatches to Arrow IPC File format (with footer).
 ///
 /// # Arguments
@@ -974,6 +856,7 @@ pub async fn export_to_arrow_ipc<T: TransportProtocol + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::datatypes::Field;
     use tokio::io::BufReader;
 
     // ==========================================================================
@@ -1027,53 +910,53 @@ mod tests {
     // Tests for CSV parsing
     // ==========================================================================
 
+    use crate::export::csv::parse_csv_row;
+
     #[test]
     fn test_parse_csv_row_simple() {
         let line = "1,hello,world";
-        let fields = parse_csv_row(line, ',', '"', 0).unwrap();
+        let (fields, in_quotes) = parse_csv_row(line, ',', '"');
+        assert!(!in_quotes);
         assert_eq!(fields, vec!["1", "hello", "world"]);
     }
 
     #[test]
     fn test_parse_csv_row_quoted() {
         let line = r#"1,"hello, world","test""#;
-        let fields = parse_csv_row(line, ',', '"', 0).unwrap();
+        let (fields, in_quotes) = parse_csv_row(line, ',', '"');
+        assert!(!in_quotes);
         assert_eq!(fields, vec!["1", "hello, world", "test"]);
     }
 
     #[test]
     fn test_parse_csv_row_escaped_quote() {
         let line = r#"1,"hello ""world""","test""#;
-        let fields = parse_csv_row(line, ',', '"', 0).unwrap();
+        let (fields, in_quotes) = parse_csv_row(line, ',', '"');
+        assert!(!in_quotes);
         assert_eq!(fields, vec!["1", r#"hello "world""#, "test"]);
     }
 
     #[test]
     fn test_parse_csv_row_empty_fields() {
         let line = "1,,3";
-        let fields = parse_csv_row(line, ',', '"', 0).unwrap();
+        let (fields, in_quotes) = parse_csv_row(line, ',', '"');
+        assert!(!in_quotes);
         assert_eq!(fields, vec!["1", "", "3"]);
     }
 
     #[test]
     fn test_parse_csv_row_custom_separator() {
         let line = "1;hello;world";
-        let fields = parse_csv_row(line, ';', '"', 0).unwrap();
+        let (fields, in_quotes) = parse_csv_row(line, ';', '"');
+        assert!(!in_quotes);
         assert_eq!(fields, vec!["1", "hello", "world"]);
     }
 
     #[test]
     fn test_parse_csv_row_unclosed_quote_error() {
         let line = r#"1,"hello"#;
-        let result = parse_csv_row(line, ',', '"', 0);
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            ExportError::CsvParseError { row, message } => {
-                assert_eq!(row, 0);
-                assert!(message.contains("Unclosed quote"));
-            }
-            _ => panic!("Expected CsvParseError"),
-        }
+        let (_, in_quotes) = parse_csv_row(line, ',', '"');
+        assert!(in_quotes, "unterminated quote should be reported");
     }
 
     // ==========================================================================
@@ -1311,28 +1194,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_build_schema_from_exasol_types() {
-        let columns = vec![
-            (
-                "id".to_string(),
-                ExasolType::Decimal {
-                    precision: 18,
-                    scale: 0,
-                },
-                false,
-            ),
-            ("name".to_string(), ExasolType::Varchar { size: 100 }, true),
-            ("active".to_string(), ExasolType::Boolean, true),
-        ];
-
-        let schema = build_schema_from_exasol_types(&columns).unwrap();
-        assert_eq!(schema.fields().len(), 3);
-        assert_eq!(schema.field(0).name(), "id");
-        assert_eq!(schema.field(1).name(), "name");
-        assert_eq!(schema.field(2).name(), "active");
-    }
-
     // ==========================================================================
     // Tests for CsvToArrowReader
     // ==========================================================================
@@ -1419,35 +1280,6 @@ mod tests {
     // ==========================================================================
     // Tests for Arrow IPC writing
     // ==========================================================================
-
-    #[tokio::test]
-    async fn test_write_arrow_ipc() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int64, false),
-            Field::new("name", DataType::Utf8, true),
-        ]));
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(arrow::array::Int64Array::from(vec![1, 2, 3])),
-                Arc::new(arrow::array::StringArray::from(vec![
-                    Some("a"),
-                    Some("b"),
-                    None,
-                ])),
-            ],
-        )
-        .unwrap();
-
-        let mut buffer = Vec::new();
-        let rows = write_arrow_ipc(&mut buffer, schema, vec![Ok(batch)])
-            .await
-            .unwrap();
-
-        assert_eq!(rows, 3);
-        assert!(!buffer.is_empty());
-    }
 
     #[tokio::test]
     async fn test_write_arrow_ipc_file() {
@@ -1574,113 +1406,6 @@ mod tests {
     fn test_exasol_type_to_arrow_hashtype() {
         let result = exasol_type_to_arrow(&ExasolType::Hashtype { byte_size: 32 }).unwrap();
         assert_eq!(result, DataType::Binary);
-    }
-
-    #[test]
-    fn test_build_schema_from_exasol_types_all_types() {
-        // Test comprehensive schema building with all supported Exasol types
-        let columns = vec![
-            ("bool_col".to_string(), ExasolType::Boolean, false),
-            ("char_col".to_string(), ExasolType::Char { size: 10 }, true),
-            (
-                "varchar_col".to_string(),
-                ExasolType::Varchar { size: 100 },
-                true,
-            ),
-            (
-                "decimal_col".to_string(),
-                ExasolType::Decimal {
-                    precision: 18,
-                    scale: 4,
-                },
-                true,
-            ),
-            ("double_col".to_string(), ExasolType::Double, true),
-            ("date_col".to_string(), ExasolType::Date, true),
-            (
-                "timestamp_col".to_string(),
-                ExasolType::Timestamp {
-                    with_local_time_zone: false,
-                },
-                true,
-            ),
-            (
-                "timestamp_tz_col".to_string(),
-                ExasolType::Timestamp {
-                    with_local_time_zone: true,
-                },
-                true,
-            ),
-            (
-                "interval_ym_col".to_string(),
-                ExasolType::IntervalYearToMonth,
-                true,
-            ),
-            (
-                "interval_ds_col".to_string(),
-                ExasolType::IntervalDayToSecond { precision: 3 },
-                true,
-            ),
-            (
-                "geometry_col".to_string(),
-                ExasolType::Geometry { srid: Some(4326) },
-                true,
-            ),
-            (
-                "hashtype_col".to_string(),
-                ExasolType::Hashtype { byte_size: 32 },
-                true,
-            ),
-        ];
-
-        let schema = build_schema_from_exasol_types(&columns).unwrap();
-
-        assert_eq!(schema.fields().len(), 12);
-
-        // Verify each field
-        assert_eq!(schema.field(0).name(), "bool_col");
-        assert_eq!(schema.field(0).data_type(), &DataType::Boolean);
-        assert!(!schema.field(0).is_nullable());
-
-        assert_eq!(schema.field(1).name(), "char_col");
-        assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
-        assert!(schema.field(1).is_nullable());
-
-        assert_eq!(schema.field(2).name(), "varchar_col");
-        assert_eq!(schema.field(2).data_type(), &DataType::Utf8);
-
-        assert_eq!(schema.field(3).name(), "decimal_col");
-        assert_eq!(schema.field(3).data_type(), &DataType::Decimal128(18, 4));
-
-        assert_eq!(schema.field(4).name(), "double_col");
-        assert_eq!(schema.field(4).data_type(), &DataType::Float64);
-
-        assert_eq!(schema.field(5).name(), "date_col");
-        assert_eq!(schema.field(5).data_type(), &DataType::Date32);
-
-        assert_eq!(schema.field(6).name(), "timestamp_col");
-        assert_eq!(
-            schema.field(6).data_type(),
-            &DataType::Timestamp(TimeUnit::Microsecond, None)
-        );
-
-        assert_eq!(schema.field(7).name(), "timestamp_tz_col");
-        assert_eq!(
-            schema.field(7).data_type(),
-            &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
-        );
-
-        assert_eq!(schema.field(8).name(), "interval_ym_col");
-        assert_eq!(schema.field(8).data_type(), &DataType::Int64);
-
-        assert_eq!(schema.field(9).name(), "interval_ds_col");
-        assert_eq!(schema.field(9).data_type(), &DataType::Int64);
-
-        assert_eq!(schema.field(10).name(), "geometry_col");
-        assert_eq!(schema.field(10).data_type(), &DataType::Binary);
-
-        assert_eq!(schema.field(11).name(), "hashtype_col");
-        assert_eq!(schema.field(11).data_type(), &DataType::Binary);
     }
 
     // ==========================================================================

--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -55,10 +55,6 @@ pub enum ExportError {
     #[error("CSV parsing error at row {row}: {message}")]
     CsvParseError { row: usize, message: String },
 
-    /// CSV parsing error (alternative for parquet module compatibility).
-    #[error("CSV parsing error at row {row}: {message}")]
-    CsvParse { row: usize, message: String },
-
     /// Decompression error.
     #[error("Decompression error: {0}")]
     DecompressionError(String),
@@ -74,24 +70,6 @@ pub enum ExportError {
     /// Export was cancelled.
     #[error("Export was cancelled")]
     Cancelled,
-
-    /// Arrow error.
-    #[error("Arrow error: {0}")]
-    Arrow(String),
-
-    /// Schema error.
-    #[error("Schema error: {0}")]
-    Schema(String),
-
-    /// Parquet error.
-    #[error("Parquet error: {0}")]
-    Parquet(String),
-}
-
-impl From<parquet::errors::ParquetError> for ExportError {
-    fn from(err: parquet::errors::ParquetError) -> Self {
-        ExportError::Parquet(err.to_string())
-    }
 }
 
 /// Options for CSV export configuration.
@@ -312,29 +290,7 @@ pub async fn export_to_stream<T: TransportProtocol + ?Sized, W: AsyncWrite + Unp
         }
 
         // Decompress if needed
-        let data = match compression {
-            Compression::Gzip => {
-                let decoder = GzDecoder::new(buffer.as_slice());
-                let mut decompressed = Vec::new();
-                std::io::Read::read_to_end(
-                    &mut std::io::BufReader::new(decoder),
-                    &mut decompressed,
-                )
-                .map_err(|e| ExportError::DecompressionError(e.to_string()))?;
-                decompressed
-            }
-            Compression::Bzip2 => {
-                let decoder = BzDecoder::new(buffer.as_slice());
-                let mut decompressed = Vec::new();
-                std::io::Read::read_to_end(
-                    &mut std::io::BufReader::new(decoder),
-                    &mut decompressed,
-                )
-                .map_err(|e| ExportError::DecompressionError(e.to_string()))?;
-                decompressed
-            }
-            Compression::None => buffer,
-        };
+        let data = decompress(buffer, compression)?;
 
         // Write to output and count rows
         writer.write_all(&data).await?;
@@ -390,29 +346,7 @@ pub async fn export_to_list<T: TransportProtocol + ?Sized>(
         }
 
         // Decompress if needed
-        let data = match compression {
-            Compression::Gzip => {
-                let decoder = GzDecoder::new(buffer.as_slice());
-                let mut decompressed = Vec::new();
-                std::io::Read::read_to_end(
-                    &mut std::io::BufReader::new(decoder),
-                    &mut decompressed,
-                )
-                .map_err(|e| ExportError::DecompressionError(e.to_string()))?;
-                decompressed
-            }
-            Compression::Bzip2 => {
-                let decoder = BzDecoder::new(buffer.as_slice());
-                let mut decompressed = Vec::new();
-                std::io::Read::read_to_end(
-                    &mut std::io::BufReader::new(decoder),
-                    &mut decompressed,
-                )
-                .map_err(|e| ExportError::DecompressionError(e.to_string()))?;
-                decompressed
-            }
-            Compression::None => buffer,
-        };
+        let data = decompress(buffer, compression)?;
 
         // Parse CSV data
         let csv_string = String::from_utf8(data).map_err(|e| ExportError::CsvParseError {
@@ -574,6 +508,29 @@ where
     result
 }
 
+/// Decompresses a buffer according to the configured compression.
+///
+/// Returns the buffer unchanged for `Compression::None`.
+fn decompress(buffer: Vec<u8>, compression: Compression) -> Result<Vec<u8>, ExportError> {
+    match compression {
+        Compression::Gzip => {
+            let decoder = GzDecoder::new(buffer.as_slice());
+            let mut decompressed = Vec::new();
+            std::io::Read::read_to_end(&mut std::io::BufReader::new(decoder), &mut decompressed)
+                .map_err(|e| ExportError::DecompressionError(e.to_string()))?;
+            Ok(decompressed)
+        }
+        Compression::Bzip2 => {
+            let decoder = BzDecoder::new(buffer.as_slice());
+            let mut decompressed = Vec::new();
+            std::io::Read::read_to_end(&mut std::io::BufReader::new(decoder), &mut decompressed)
+                .map_err(|e| ExportError::DecompressionError(e.to_string()))?;
+            Ok(decompressed)
+        }
+        Compression::None => Ok(buffer),
+    }
+}
+
 /// Parses CSV data into a vector of rows.
 fn parse_csv(
     data: &str,
@@ -652,6 +609,51 @@ fn parse_csv(
     }
 
     Ok(rows)
+}
+
+/// Parses a single CSV line into its fields, handling RFC-style quoting.
+///
+/// A field is opened/closed by `delimiter`; a doubled delimiter inside a quoted
+/// field is an escaped delimiter. `separator` splits fields when not inside
+/// quotes. This operates on a single already-split line and therefore does not
+/// handle newlines embedded in quoted fields (callers split on newlines first).
+///
+/// Returns the parsed fields together with a flag indicating whether the line
+/// ended while still inside a quoted field (unterminated quote). Callers decide
+/// whether an unterminated quote is an error.
+pub(crate) fn parse_csv_row(line: &str, separator: char, delimiter: char) -> (Vec<String>, bool) {
+    let mut fields = Vec::new();
+    let mut current_field = String::new();
+    let mut in_quotes = false;
+    let mut chars = line.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if in_quotes {
+            if c == delimiter {
+                // Check for escaped quote (doubled delimiter)
+                if chars.peek() == Some(&delimiter) {
+                    current_field.push(delimiter);
+                    chars.next();
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                current_field.push(c);
+            }
+        } else if c == delimiter {
+            in_quotes = true;
+        } else if c == separator {
+            fields.push(current_field);
+            current_field = String::new();
+        } else {
+            current_field.push(c);
+        }
+    }
+
+    // Don't forget the last field
+    fields.push(current_field);
+
+    (fields, in_quotes)
 }
 
 #[cfg(test)]

--- a/src/export/parquet.rs
+++ b/src/export/parquet.rs
@@ -25,11 +25,9 @@
 //! ).await?;
 //! ```
 
-use std::io::{Cursor, Write};
+use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
-
-use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use arrow::array::{
     ArrayRef, BooleanBuilder, Date32Builder, Decimal128Builder, Float64Builder, StringBuilder,
@@ -320,72 +318,6 @@ pub async fn export_to_parquet_stream<W: Write + Send>(
     Ok(total_rows)
 }
 
-/// Export data from Exasol to an async Parquet stream.
-///
-/// This function exports data from Exasol (table or query) to any writer implementing `AsyncWrite`.
-/// Useful for writing to async network streams, tokio files, or custom async destinations.
-///
-/// Since Parquet writers are synchronous, this function writes to an in-memory buffer first,
-/// then asynchronously writes the buffer to the output.
-///
-/// # Arguments
-///
-/// * `csv_data` - CSV data as bytes (simulating what would come from HTTP transport)
-/// * `schema` - Arrow schema for the data
-/// * `writer` - Any type implementing `AsyncWrite + Unpin`
-/// * `options` - Export options
-///
-/// # Returns
-///
-/// The number of rows exported.
-///
-/// # Errors
-///
-/// Returns `ParquetExportError` if:
-/// - CSV parsing fails
-/// - Arrow conversion fails
-/// - Parquet writing fails
-/// - Async IO fails
-pub async fn export_to_parquet_async_stream<W: AsyncWrite + Unpin + Send>(
-    csv_data: &[u8],
-    schema: Arc<Schema>,
-    writer: &mut W,
-    options: ParquetExportOptions,
-) -> Result<u64, ParquetExportError> {
-    // Parse CSV data into record batches
-    let batches = csv_to_record_batches(csv_data, &schema, &options)?;
-
-    // Calculate total rows
-    let total_rows: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
-
-    // Create writer properties with compression
-    let props = WriterProperties::builder()
-        .set_compression(options.compression.to_codec())
-        .set_encoding(Encoding::PLAIN)
-        .build();
-
-    // Write to in-memory buffer first (Parquet writer is synchronous)
-    let mut buffer = Cursor::new(Vec::new());
-    {
-        let mut parquet_writer = ArrowWriter::try_new(&mut buffer, schema.clone(), Some(props))?;
-
-        // Write all batches
-        for batch in batches {
-            parquet_writer.write(&batch)?;
-        }
-
-        // Close the writer to flush remaining data
-        parquet_writer.close()?;
-    }
-
-    // Asynchronously write the buffer to the output
-    let data = buffer.into_inner();
-    writer.write_all(&data).await?;
-    writer.flush().await?;
-
-    Ok(total_rows)
-}
-
 /// Convert CSV data to Arrow RecordBatches.
 ///
 /// # Arguments
@@ -476,34 +408,12 @@ fn parse_csv_line(
     row_idx: usize,
     expected_columns: usize,
 ) -> Result<Vec<Option<String>>, ParquetExportError> {
-    let mut values = Vec::with_capacity(expected_columns);
-    let mut current_value = String::new();
-    let mut in_quotes = false;
-    let mut chars = line.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        if c == options.column_delimiter {
-            if in_quotes {
-                // Check for escaped quote (doubled delimiter)
-                if chars.peek() == Some(&options.column_delimiter) {
-                    current_value.push(c);
-                    chars.next(); // Skip the second quote
-                } else {
-                    in_quotes = false;
-                }
-            } else {
-                in_quotes = true;
-            }
-        } else if c == options.column_separator && !in_quotes {
-            values.push(parse_csv_value(&current_value, options));
-            current_value.clear();
-        } else {
-            current_value.push(c);
-        }
-    }
-
-    // Push the last value
-    values.push(parse_csv_value(&current_value, options));
+    let (fields, _in_quotes) =
+        crate::export::csv::parse_csv_row(line, options.column_separator, options.column_delimiter);
+    let values: Vec<Option<String>> = fields
+        .iter()
+        .map(|field| parse_csv_value(field, options))
+        .collect();
 
     // Validate column count
     if values.len() != expected_columns {
@@ -1516,155 +1426,5 @@ mod tests {
         // Verify file content starts with PAR1
         let content = fs::read(&file_path).unwrap();
         assert_eq!(&content[0..4], b"PAR1");
-    }
-
-    // ==========================================================================
-    // Tests for AsyncWrite stream export
-    // ==========================================================================
-
-    #[tokio::test]
-    async fn test_export_to_parquet_async_stream_simple() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int64, true),
-            Field::new("name", DataType::Utf8, true),
-        ]));
-        let options = ParquetExportOptions::default();
-        let csv_data = b"id,name\n1,Alice\n2,Bob\n3,Charlie";
-
-        let mut buffer = Vec::new();
-        let mut cursor = std::io::Cursor::new(&mut buffer);
-
-        // Use tokio's async write wrapper
-        let rows = export_to_parquet_async_stream(csv_data, schema, &mut cursor, options)
-            .await
-            .unwrap();
-
-        assert_eq!(rows, 3);
-        assert!(!buffer.is_empty());
-        // Verify it's a valid Parquet file (magic bytes: PAR1)
-        assert_eq!(&buffer[0..4], b"PAR1");
-    }
-
-    #[tokio::test]
-    async fn test_export_to_parquet_async_stream_with_compression() {
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, true)]));
-
-        // Test with Gzip compression
-        let options = ParquetExportOptions {
-            compression: ParquetCompression::Gzip,
-            ..Default::default()
-        };
-        let csv_data = b"id\n1\n2\n3";
-
-        let mut buffer = Vec::new();
-        let mut cursor = std::io::Cursor::new(&mut buffer);
-
-        let rows = export_to_parquet_async_stream(csv_data, schema.clone(), &mut cursor, options)
-            .await
-            .unwrap();
-
-        assert_eq!(rows, 3);
-        assert!(!buffer.is_empty());
-        assert_eq!(&buffer[0..4], b"PAR1");
-    }
-
-    #[tokio::test]
-    async fn test_export_to_parquet_async_stream_schema_preservation() {
-        // Test that complex schema types are preserved through Parquet export
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("bool_col", DataType::Boolean, true),
-            Field::new("int_col", DataType::Int64, true),
-            Field::new("float_col", DataType::Float64, true),
-            Field::new("str_col", DataType::Utf8, true),
-            Field::new("decimal_col", DataType::Decimal128(18, 2), true),
-            Field::new("date_col", DataType::Date32, true),
-        ]));
-        let options = ParquetExportOptions::default();
-        let csv_data = b"bool_col,int_col,float_col,str_col,decimal_col,date_col\ntrue,42,3.14,hello,123.45,2024-01-15";
-
-        let mut buffer = Vec::new();
-        let mut cursor = std::io::Cursor::new(&mut buffer);
-
-        let rows = export_to_parquet_async_stream(csv_data, schema.clone(), &mut cursor, options)
-            .await
-            .unwrap();
-
-        assert_eq!(rows, 1);
-        assert!(!buffer.is_empty());
-
-        // Read the Parquet file back and verify schema
-        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-        let bytes = bytes::Bytes::from(buffer);
-        let builder = ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
-        let parquet_schema = builder.schema();
-
-        // Verify schema field names match
-        assert_eq!(parquet_schema.fields().len(), 6);
-        assert_eq!(parquet_schema.field(0).name(), "bool_col");
-        assert_eq!(parquet_schema.field(1).name(), "int_col");
-        assert_eq!(parquet_schema.field(2).name(), "float_col");
-        assert_eq!(parquet_schema.field(3).name(), "str_col");
-        assert_eq!(parquet_schema.field(4).name(), "decimal_col");
-        assert_eq!(parquet_schema.field(5).name(), "date_col");
-    }
-
-    #[tokio::test]
-    async fn test_export_to_parquet_roundtrip_data_integrity() {
-        // Test that data values are correctly preserved through Parquet export and read back
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int64, true),
-            Field::new("name", DataType::Utf8, true),
-            Field::new("active", DataType::Boolean, true),
-        ]));
-        let options = ParquetExportOptions::default();
-        let csv_data = b"id,name,active\n1,Alice,true\n2,Bob,false\n3,,true";
-
-        let mut buffer = Vec::new();
-        let mut cursor = std::io::Cursor::new(&mut buffer);
-
-        let rows = export_to_parquet_async_stream(csv_data, schema, &mut cursor, options)
-            .await
-            .unwrap();
-
-        assert_eq!(rows, 3);
-
-        // Read the Parquet file back and verify data
-        use arrow::array::{Array, BooleanArray, Int64Array, StringArray};
-        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-
-        let bytes = bytes::Bytes::from(buffer);
-        let builder = ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
-        let mut reader = builder.build().unwrap();
-
-        let batch = reader.next().unwrap().unwrap();
-        assert_eq!(batch.num_rows(), 3);
-
-        // Verify column values
-        let id_col = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(id_col.value(0), 1);
-        assert_eq!(id_col.value(1), 2);
-        assert_eq!(id_col.value(2), 3);
-
-        let name_col = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        assert_eq!(name_col.value(0), "Alice");
-        assert_eq!(name_col.value(1), "Bob");
-        assert!(name_col.is_null(2)); // Third row has NULL name
-
-        let active_col = batch
-            .column(2)
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .unwrap();
-        assert!(active_col.value(0));
-        assert!(!active_col.value(1));
-        assert!(active_col.value(2));
     }
 }

--- a/src/import/csv.rs
+++ b/src/import/csv.rs
@@ -380,11 +380,7 @@ fn detect_compression(file_path: &Path, explicit_compression: Compression) -> Co
 ///
 /// `true` if the file appears to be compressed.
 fn is_compressed_file(file_path: &Path) -> bool {
-    let path_str = file_path.to_string_lossy().to_lowercase();
-    path_str.ends_with(".gz")
-        || path_str.ends_with(".gzip")
-        || path_str.ends_with(".bz2")
-        || path_str.ends_with(".bzip2")
+    detect_compression(file_path, Compression::None) != Compression::None
 }
 
 /// Import CSV data from a file path.

--- a/src/query/import.rs
+++ b/src/query/import.rs
@@ -370,19 +370,6 @@ impl ImportQuery {
         self
     }
 
-    /// Get the configured file name with the appropriate extension.
-    ///
-    /// For `ImportFormat::Parquet`, the extension is always `.parquet` and
-    /// any configured compression suffix is bypassed. For `ImportFormat::Csv`,
-    /// the extension reflects the configured `Compression`.
-    fn get_file_name(&self) -> String {
-        let base_name = strip_known_extensions(&self.file_name);
-        match self.format {
-            ImportFormat::Parquet => format!("{}.parquet", base_name),
-            ImportFormat::Csv => format!("{}{}", base_name, self.compression.extension()),
-        }
-    }
-
     /// Build the complete IMPORT SQL statement.
     ///
     /// # Returns
@@ -479,7 +466,7 @@ impl ImportQuery {
 
             // FILE clause
             sql.push_str("\nFILE '");
-            sql.push_str(&self.get_file_name());
+            sql.push_str(&self.get_file_name_for(&self.file_name));
             sql.push('\'');
         }
 
@@ -534,9 +521,11 @@ impl ImportQuery {
         sql
     }
 
-    /// Get file name with the appropriate extension for multi-file entries.
+    /// Get a file name with the appropriate extension for the configured format.
     ///
-    /// Mirrors `get_file_name`'s format-aware extension policy.
+    /// For `ImportFormat::Parquet`, the extension is always `.parquet` and
+    /// any configured compression suffix is bypassed. For `ImportFormat::Csv`,
+    /// the extension reflects the configured `Compression`.
     fn get_file_name_for(&self, base_name: &str) -> String {
         let base = strip_known_extensions(base_name);
         match self.format {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -52,23 +52,3 @@ pub use import::{
 pub use prepared::PreparedStatement;
 pub use results::{QueryMetadata, ResultSet, ResultSetIterator};
 pub use statement::{Parameter, Statement, StatementType};
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_module_exports() {
-        // Verify that key types are exported and accessible
-        // This is a compile-time check more than a runtime check
-        let _: Option<StatementType> = None;
-        let _: Option<Parameter> = None;
-    }
-
-    #[test]
-    fn test_prepared_statement_export() {
-        // Verify that PreparedStatement is accessible
-        // This is a compile-time check
-        fn _takes_prepared_stmt(_stmt: PreparedStatement) {}
-    }
-}

--- a/src/transport/http_transport.rs
+++ b/src/transport/http_transport.rs
@@ -33,6 +33,8 @@ use tokio_rustls::TlsConnector;
 
 use crate::error::TransportError;
 
+use super::tls::NoVerifier;
+
 /// EXA tunneling protocol magic number.
 /// This is sent as the first 4 bytes of the handshake.
 pub const EXA_MAGIC_NUMBER: u32 = 0x02212102;
@@ -806,57 +808,6 @@ impl HttpTransportClient {
         self.write_http_response(200, "OK", &[], None).await?;
 
         Ok((request, body))
-    }
-}
-
-/// A certificate verifier that accepts any certificate.
-/// Used for Exasol's ad-hoc TLS mode where verification is done via fingerprint in SQL.
-#[derive(Debug)]
-struct NoVerifier;
-
-impl rustls::client::danger::ServerCertVerifier for NoVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &rustls::pki_types::ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: rustls::pki_types::UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::danger::ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        vec![
-            rustls::SignatureScheme::RSA_PKCS1_SHA256,
-            rustls::SignatureScheme::RSA_PKCS1_SHA384,
-            rustls::SignatureScheme::RSA_PKCS1_SHA512,
-            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
-            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
-            rustls::SignatureScheme::RSA_PSS_SHA256,
-            rustls::SignatureScheme::RSA_PSS_SHA384,
-            rustls::SignatureScheme::RSA_PSS_SHA512,
-            rustls::SignatureScheme::ED25519,
-        ]
     }
 }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -45,6 +45,7 @@ pub mod messages;
 #[cfg(feature = "native")]
 pub mod native;
 pub mod protocol;
+pub(crate) mod tls;
 #[cfg(feature = "websocket")]
 pub mod websocket;
 

--- a/src/transport/native/constants.rs
+++ b/src/transport/native/constants.rs
@@ -1,9 +1,6 @@
 /// Magic value sent at the start of a login handshake.
 pub const LOGIN_MAGIC: u32 = 0x01121201;
 
-/// Magic value sent for proxy connections.
-pub const PROXY_MAGIC: u32 = 0x02212102;
-
 /// Maximum protocol version we support (matches Exasol 2025.1).
 pub const PROTOCOL_VERSION: u32 = 21;
 
@@ -25,20 +22,8 @@ pub const CMD_EXECUTE: u8 = 12;
 /// Close a result set handle.
 pub const CMD_CLOSE_RESULTSET: u8 = 13;
 
-/// Fetch rows from a result set.
-pub const CMD_FETCH: u8 = 14;
-
-/// Retrieve cluster host information.
-pub const CMD_GET_HOSTS: u8 = 16;
-
-/// Execute a batch of parameter sets.
-pub const CMD_EXECUTE_BATCH: u8 = 17;
-
 /// Close a prepared statement handle.
 pub const CMD_CLOSE_PREPARED: u8 = 18;
-
-/// Enter parallel execution mode.
-pub const CMD_ENTER_PARALLEL: u8 = 30;
 
 /// Disconnect from the server.
 pub const CMD_DISCONNECT: u8 = 32;
@@ -51,12 +36,6 @@ pub const CMD_SET_ATTRIBUTES: u8 = 35;
 
 /// Fetch rows (v2, with binary column data).
 pub const CMD_FETCH2: u8 = 36;
-
-/// Abort a running query.
-pub const CMD_ABORT_QUERY: u8 = 37;
-
-/// Continue after a "still executing" response.
-pub const CMD_CONTINUE: u8 = 38;
 
 /// Response: row count (DML result).
 pub const R_ROW_COUNT: i8 = 0;
@@ -88,9 +67,6 @@ pub const R_EMPTY: i8 = -2;
 /// Handle value indicating a small (inline) result set.
 pub const SMALL_RESULTSET: i32 = -3;
 
-/// Handle value indicating an invalid result set.
-pub const INVALID_RESULTSET: i32 = -4;
-
 /// Handle value used for parameter descriptions.
 pub const PARAMETER_DESCRIPTION: i32 = -5;
 
@@ -98,19 +74,12 @@ pub const ATTR_USERNAME: u16 = 1;
 pub const ATTR_CLIENTNAME: u16 = 2;
 pub const ATTR_CLIENTOS: u16 = 3;
 pub const ATTR_DRIVERNAME: u16 = 4;
-pub const ATTR_LANGUAGE: u16 = 5;
 pub const ATTR_SESSIONID: u16 = 6;
 pub const ATTR_AUTOCOMMIT: u16 = 7;
 pub const ATTR_CLIENTVERSION: u16 = 10;
-pub const ATTR_PASSWORD: u16 = 12;
 pub const ATTR_TRANSACTION_STATE: u16 = 17;
 pub const ATTR_PROTOCOL_VERSION: u16 = 19;
-pub const ATTR_DATETIME_FORMAT: u16 = 20;
-pub const ATTR_DATE_FORMAT: u16 = 21;
-pub const ATTR_CURRENT_SCHEMA: u16 = 22;
-pub const ATTR_NUMERIC_CHARACTERS: u16 = 23;
 pub const ATTR_DATA_MESSAGE_SIZE: u16 = 26;
-pub const ATTR_DATE_LANGUAGE: u16 = 31;
 pub const ATTR_PUBLIC_KEY: u16 = 32;
 pub const ATTR_RANDOM_PHRASE: u16 = 33;
 pub const ATTR_ENCODED_PASSWORD: u16 = 34;
@@ -123,13 +92,10 @@ pub const ATTR_CLIENT_SEND_KEY: u16 = 54;
 pub const ATTR_SNAPSHOT_TRANSACTIONS_ENABLED: u16 = 55;
 pub const ATTR_CLIENT_KEYS_LEN: u16 = 56;
 pub const ATTR_ENCRYPTION_REQUIRED: u16 = 57;
-pub const ATTR_DEFAULT_LIKE_ESCAPE_CHAR: u16 = 58;
-pub const ATTR_IDENTIFIER_QUOTE_STRING: u16 = 59;
 
 pub const ATTR_RELEASE_VERSION: u16 = 8;
 pub const ATTR_DATABASE_NAME: u16 = 37;
 pub const ATTR_PRODUCT_NAME: u16 = 38;
-pub const ATTR_CURRENT_CATALOG: u16 = 39;
 
 // Command-level pseudo-attribute IDs used by our attribute-based encoding
 // for SQL text, handles, and row counts in CMD_EXECUTE/CMD_FETCH messages.
@@ -140,12 +106,6 @@ pub const ATTR_SQL_TEXT: u16 = 200;
 pub const ATTR_RESULT_SET_HANDLE: u16 = 201;
 pub const ATTR_STATEMENT_HANDLE: u16 = 202;
 pub const ATTR_NUM_ROWS: u16 = 203;
-
-/// Wire type: byte (u8).
-pub const T_BYTE: u32 = 1;
-
-/// Wire type: short (i16).
-pub const T_SHORT: u32 = 2;
 
 /// Wire type: small integer (i32).
 pub const T_SMALLINT: u32 = 4;
@@ -201,12 +161,6 @@ pub const T_SMALLDECIMAL: u32 = 63;
 /// Wire type: big decimal.
 pub const T_BIGDECIMAL: u32 = 64;
 
-/// Column property flag: nullable.
-pub const COL_NULLABLE: u16 = 0x0001;
-
-/// Column property flag: varchar.
-pub const COL_VARCHAR: u16 = 0x0200;
-
 /// VCFlag: is varchar.
 pub const IS_VARCHAR: u8 = 0x80;
 
@@ -222,15 +176,6 @@ pub const MAX_DATA_MESSAGE_SIZE: u32 = 64 * 1024 * 1024;
 /// ChaCha20 key length in bytes.
 pub const CHACHA20_KEY_LEN: usize = 32;
 
-/// Transaction state: normal (in transaction).
-pub const TRANSACTION_NORMAL: u32 = 0;
-
-/// Transaction state: committed.
-pub const TRANSACTION_COMMITTED: u32 = 1;
-
-/// Transaction state: rolled back.
-pub const TRANSACTION_ROLLED_BACK: u32 = 2;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,11 +183,6 @@ mod tests {
     #[test]
     fn login_magic_matches_protocol_spec() {
         assert_eq!(LOGIN_MAGIC, 0x01121201);
-    }
-
-    #[test]
-    fn proxy_magic_matches_protocol_spec() {
-        assert_eq!(PROXY_MAGIC, 0x02212102);
     }
 
     #[test]
@@ -276,7 +216,6 @@ mod tests {
     #[test]
     fn special_resultset_handles_are_negative() {
         assert_eq!(SMALL_RESULTSET, -3);
-        assert_eq!(INVALID_RESULTSET, -4);
         assert_eq!(PARAMETER_DESCRIPTION, -5);
     }
 }

--- a/src/transport/native/handshake.rs
+++ b/src/transport/native/handshake.rs
@@ -54,30 +54,6 @@ pub fn build_login_packet(username: &str) -> Vec<u8> {
     buf
 }
 
-/// Parse the server's login response to extract session attributes.
-///
-/// The server sends: [total_size: u32 LE] followed by attribute data.
-/// Returns the parsed attributes containing public key, session info, etc.
-pub fn parse_login_response(data: &[u8]) -> Result<AttributeSet, TransportError> {
-    if data.len() < 4 {
-        return Err(TransportError::ProtocolError(
-            "Login response too short".into(),
-        ));
-    }
-    let total_size = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
-    if data.len() < 4 + total_size {
-        return Err(TransportError::ProtocolError(format!(
-            "Login response truncated: expected {} bytes, got {}",
-            4 + total_size,
-            data.len()
-        )));
-    }
-    let attr_data = &data[4..4 + total_size];
-    // Count attributes by scanning the data
-    let count = count_attributes(attr_data);
-    super::attributes::parse_attributes(attr_data, count)
-}
-
 /// Build the second-phase authentication message containing encrypted password and keys.
 ///
 /// Sends CMD_SET_ATTRIBUTES with the RSA-encrypted password and ChaCha20 keys.
@@ -349,83 +325,6 @@ fn exasol_encode_pwd(
     Ok(encrypted)
 }
 
-/// Count the number of attributes in a binary attribute buffer.
-///
-/// Scans forward through the buffer counting each attribute entry.
-fn count_attributes(data: &[u8]) -> u32 {
-    let mut count = 0u32;
-    let mut offset = 0;
-    while offset + 2 <= data.len() {
-        let id = u16::from_le_bytes([data[offset], data[offset + 1]]);
-        offset += 2;
-        match attribute_wire_size(id) {
-            WireSize::Bool => {
-                if offset >= data.len() {
-                    break;
-                }
-                offset += 1;
-            }
-            WireSize::I32 => {
-                if offset + 4 > data.len() {
-                    break;
-                }
-                offset += 4;
-            }
-            WireSize::I64 => {
-                if offset + 8 > data.len() {
-                    break;
-                }
-                offset += 8;
-            }
-            WireSize::LengthPrefixed => {
-                if offset + 4 > data.len() {
-                    break;
-                }
-                let len = u32::from_le_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                ]) as usize;
-                offset += 4;
-                if offset + len > data.len() {
-                    break;
-                }
-                offset += len;
-            }
-        }
-        count += 1;
-    }
-    count
-}
-
-enum WireSize {
-    Bool,
-    I32,
-    I64,
-    LengthPrefixed,
-}
-
-fn attribute_wire_size(id: u16) -> WireSize {
-    match id {
-        ATTR_AUTOCOMMIT
-        | ATTR_TSUTC_ENABLED
-        | ATTR_ENCRYPTION_REQUIRED
-        | ATTR_SNAPSHOT_TRANSACTIONS_ENABLED
-        | ATTR_TRANSACTION_STATE => WireSize::Bool,
-        ATTR_PROTOCOL_VERSION
-        | ATTR_QUERY_TIMEOUT
-        | ATTR_QUERY_CACHE_ACCESS
-        | ATTR_CLIENT_KEYS_LEN => WireSize::I32,
-        ATTR_SESSIONID
-        | ATTR_DATA_MESSAGE_SIZE
-        | ATTR_RESULT_SET_HANDLE
-        | ATTR_STATEMENT_HANDLE
-        | ATTR_NUM_ROWS => WireSize::I64,
-        _ => WireSize::LengthPrefixed,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -457,20 +356,5 @@ mod tests {
         let msg_len = u32::from_le_bytes([packet[4], packet[5], packet[6], packet[7]]) as usize;
         // Total packet = 8 (magic + msg_len) + msg_len
         assert_eq!(packet.len(), 8 + msg_len);
-    }
-
-    #[test]
-    fn count_attributes_empty() {
-        assert_eq!(count_attributes(&[]), 0);
-    }
-
-    #[test]
-    fn count_attributes_roundtrip() {
-        let mut attrs = AttributeSet::new();
-        attrs.add(ATTR_USERNAME, AttributeValue::String("sys".into()));
-        attrs.add(ATTR_AUTOCOMMIT, AttributeValue::Bool(true));
-        attrs.add(ATTR_PROTOCOL_VERSION, AttributeValue::Int32(21));
-        let bytes = attrs.serialize();
-        assert_eq!(count_attributes(&bytes), 3);
     }
 }

--- a/src/transport/native/mod.rs
+++ b/src/transport/native/mod.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use rustls::pki_types::CertificateDer;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio_rustls::client::TlsStream;
@@ -21,6 +20,7 @@ use super::messages::{ColumnInfo, ResultData, ResultPayload, ResultSetHandle, Se
 use super::protocol::{
     ConnectionParams, Credentials, PreparedStatementHandle, QueryResult, TransportProtocol,
 };
+use super::tls::{FingerprintVerifier, NoVerifier};
 
 use self::attributes::{AttributeSet, AttributeValue};
 use self::constants::*;
@@ -672,115 +672,6 @@ impl NativeTcpTransport {
 impl Default for NativeTcpTransport {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-// --- TLS certificate verifiers (reused from websocket.rs) ---
-
-fn all_supported_verify_schemes() -> Vec<rustls::SignatureScheme> {
-    vec![
-        rustls::SignatureScheme::RSA_PKCS1_SHA256,
-        rustls::SignatureScheme::RSA_PKCS1_SHA384,
-        rustls::SignatureScheme::RSA_PKCS1_SHA512,
-        rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-        rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
-        rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
-        rustls::SignatureScheme::RSA_PSS_SHA256,
-        rustls::SignatureScheme::RSA_PSS_SHA384,
-        rustls::SignatureScheme::RSA_PSS_SHA512,
-        rustls::SignatureScheme::ED25519,
-    ]
-}
-
-#[derive(Debug)]
-struct NoVerifier;
-
-impl rustls::client::danger::ServerCertVerifier for NoVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &rustls::pki_types::ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: rustls::pki_types::UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::danger::ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        all_supported_verify_schemes()
-    }
-}
-
-#[derive(Debug)]
-struct FingerprintVerifier {
-    expected_fingerprint: String,
-}
-
-impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
-    fn verify_server_cert(
-        &self,
-        end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &rustls::pki_types::ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: rustls::pki_types::UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        use aws_lc_rs::digest;
-        let fingerprint = digest::digest(&digest::SHA256, end_entity.as_ref());
-        let actual: String = fingerprint
-            .as_ref()
-            .iter()
-            .map(|b| format!("{:02x}", b))
-            .collect();
-        if actual == self.expected_fingerprint {
-            Ok(rustls::client::danger::ServerCertVerified::assertion())
-        } else {
-            Err(rustls::Error::General(format!(
-                "Certificate fingerprint mismatch: expected {}, got {}",
-                self.expected_fingerprint, actual
-            )))
-        }
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        all_supported_verify_schemes()
     }
 }
 

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -1,0 +1,130 @@
+//! Shared rustls certificate verifiers used across the transport implementations.
+//!
+//! The WebSocket, HTTP-transport, and native-TCP code paths all need the same two
+//! custom [`rustls::client::danger::ServerCertVerifier`] implementations:
+//!
+//! - [`NoVerifier`] accepts any certificate (used when validation is disabled).
+//! - [`FingerprintVerifier`] validates by SHA-256 fingerprint of the DER-encoded
+//!   certificate, bypassing hostname and CA-chain validation.
+//!
+//! Both report the same set of supported signature schemes via
+//! [`all_supported_verify_schemes`].
+
+use rustls::pki_types::CertificateDer;
+
+/// The signature schemes advertised by the custom verifiers.
+pub(crate) fn all_supported_verify_schemes() -> Vec<rustls::SignatureScheme> {
+    vec![
+        rustls::SignatureScheme::RSA_PKCS1_SHA256,
+        rustls::SignatureScheme::RSA_PKCS1_SHA384,
+        rustls::SignatureScheme::RSA_PKCS1_SHA512,
+        rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+        rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+        rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+        rustls::SignatureScheme::RSA_PSS_SHA256,
+        rustls::SignatureScheme::RSA_PSS_SHA384,
+        rustls::SignatureScheme::RSA_PSS_SHA512,
+        rustls::SignatureScheme::ED25519,
+    ]
+}
+
+/// A certificate verifier that accepts any certificate.
+/// Used when certificate validation is disabled.
+#[derive(Debug)]
+pub(crate) struct NoVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        all_supported_verify_schemes()
+    }
+}
+
+/// A certificate verifier that validates by SHA-256 fingerprint of the DER-encoded certificate.
+/// Bypasses hostname and CA chain validation.
+///
+/// Only the WebSocket and native-TCP transports construct this; gate it on those
+/// features so a `--no-default-features` build (HTTP transport only) does not warn.
+#[cfg(any(feature = "websocket", feature = "native"))]
+#[derive(Debug)]
+pub(crate) struct FingerprintVerifier {
+    pub(crate) expected_fingerprint: String,
+}
+
+#[cfg(any(feature = "websocket", feature = "native"))]
+impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        use aws_lc_rs::digest;
+        let fingerprint = digest::digest(&digest::SHA256, end_entity.as_ref());
+        let actual: String = fingerprint
+            .as_ref()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect();
+        if actual == self.expected_fingerprint {
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        } else {
+            Err(rustls::Error::General(format!(
+                "Certificate fingerprint mismatch: expected {}, got {}",
+                self.expected_fingerprint, actual
+            )))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        all_supported_verify_schemes()
+    }
+}

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -11,7 +11,6 @@ use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
 use num_bigint::BigUint;
-use rustls::pki_types::CertificateDer;
 use tokio::net::TcpStream;
 use tokio_tungstenite::{
     connect_async_tls_with_config,
@@ -32,6 +31,7 @@ use super::messages::{
 use super::protocol::{
     ConnectionParams, Credentials, PreparedStatementHandle, QueryResult, TransportProtocol,
 };
+use super::tls::{FingerprintVerifier, NoVerifier};
 
 /// WebSocket transport implementation.
 ///
@@ -810,118 +810,6 @@ impl TransportProtocol for WebSocketTransport {
         let response: SetAttributesResponse = self.send_receive(&request).await?;
         self.check_status(&response.status, &response.exception)?;
         Ok(())
-    }
-}
-
-/// Returns the set of signature schemes supported by the custom certificate verifiers.
-fn all_supported_verify_schemes() -> Vec<rustls::SignatureScheme> {
-    vec![
-        rustls::SignatureScheme::RSA_PKCS1_SHA256,
-        rustls::SignatureScheme::RSA_PKCS1_SHA384,
-        rustls::SignatureScheme::RSA_PKCS1_SHA512,
-        rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-        rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
-        rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
-        rustls::SignatureScheme::RSA_PSS_SHA256,
-        rustls::SignatureScheme::RSA_PSS_SHA384,
-        rustls::SignatureScheme::RSA_PSS_SHA512,
-        rustls::SignatureScheme::ED25519,
-    ]
-}
-
-/// A certificate verifier that accepts any certificate.
-/// Used when certificate validation is disabled.
-#[derive(Debug)]
-struct NoVerifier;
-
-impl rustls::client::danger::ServerCertVerifier for NoVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &rustls::pki_types::ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: rustls::pki_types::UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::danger::ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        all_supported_verify_schemes()
-    }
-}
-
-/// A certificate verifier that validates by SHA-256 fingerprint of the DER-encoded certificate.
-/// Bypasses hostname and CA chain validation.
-#[derive(Debug)]
-struct FingerprintVerifier {
-    expected_fingerprint: String,
-}
-
-impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
-    fn verify_server_cert(
-        &self,
-        end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &rustls::pki_types::ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: rustls::pki_types::UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        use aws_lc_rs::digest;
-        let fingerprint = digest::digest(&digest::SHA256, end_entity.as_ref());
-        let actual: String = fingerprint
-            .as_ref()
-            .iter()
-            .map(|b| format!("{:02x}", b))
-            .collect();
-        if actual == self.expected_fingerprint {
-            Ok(rustls::client::danger::ServerCertVerified::assertion())
-        } else {
-            Err(rustls::Error::General(format!(
-                "Certificate fingerprint mismatch: expected {}, got {}",
-                self.expected_fingerprint, actual
-            )))
-        }
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        all_supported_verify_schemes()
     }
 }
 


### PR DESCRIPTION
## Summary

Whole-repo over-engineering audit (ponytail) + orchestrated fixes. **Net −1178 lines** (16 files, +256/−1434) of verified-dead internal code and copy-pasted logic.

**No public-API changes.** Documented/exported surface was intentionally left in place even though internals don't use it (a library legitimately exports for consumers): `ArrowConverter`, `ResultSetIterator`, the `blocking_*` sync API, `ArrowToCsvWriter`, `CsvToArrowReader`, public error variants, and `SessionConfig` fields. Removing those is a deliberate semver-breaking decision, not a cleanup.

## Removed (zero non-test callers, not re-exported)
- **error**: `AdbcErrorCode` enum + `Display` + `to_adbc_code()` — unused; FFI uses `adbc_core::Status` directly
- **connection/session**: `SessionManager` (+ Debug impl) and dead `Session` methods/fields (`get/set/remove_attribute`, idle/timeout helpers, `mark_error`)
- **transport/native/handshake**: `parse_login_response`, `count_attributes`, `attribute_wire_size`
- **transport/native/constants**: ~30 never-referenced `CMD_*`/`ATTR_*`/`COL_*`/`T_*`/`TRANSACTION_*` constants
- **export**: `write_arrow_ipc` stream variant, `build_schema_from_exasol_types`, `export_to_parquet_async_stream`, unused `ExportError` variants
- **query**: compile-only export tests; folded `get_file_name` into `get_file_name_for`

## De-duplicated
- **TLS verifiers** (`NoVerifier`/`FingerprintVerifier`/`all_supported_verify_schemes`) hoisted from 3 copy-pasted sites into new `src/transport/tls.rs`
- **export CSV**: three hand-rolled CSV parsers unified into one `parse_csv_row`; gzip/bzip2 decompress extracted into one helper
- **import csv**: `is_compressed_file` expressed via `detect_compression`

## Intentionally skipped (flagged but unsafe for a behaviour-preserving cleanup)
- CSV value formatters in import `arrow.rs`/`parquet.rs` — outputs genuinely differ (scientific notation, decimal sign handling, chrono vs hand-rolled dates); merging would change bytes
- SQL-injection blocklist in `query/statement.rs` (security path) and hand-rolled date math (correctness)

## Verification (live Exasol Docker 2025.2.1)
- unit: **1011 ok**
- integration: **63 ok**, 2 failures (`*_uri_schema_*`) that are **pre-existing on `main`** — they pass in isolation and fail only in the full single-threaded run due to env-mutating unit tests in `tests/common/mod.rs`; confirmed identical 63/2 on a clean `main`
- import/export: **42 ok** · driver-manager: **41 ok**
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean under pinned **1.92.0**

_Incidental: 2-hunk `cargo fmt` fix to `examples/prepared_statements.rs` to keep the tree fmt-clean under 1.92.0._

🤖 Generated with [Claude Code](https://claude.com/claude-code)