### PR TITLE
chore: bump exarrow-rs to 0.13.0 (version + test env-isolation + ADR-007 alignment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.13.0
+
+- Feat: `Connection::builder()` now exposes `.validate_server_certificate(bool)`, mirroring the connection-string `validateservercertificate` parameter. Previously the builder could only reach a self-signed Exasol (e.g. the Docker image) by disabling TLS entirely; it can now connect over TLS while accepting a self-signed certificate.
+- Refactor: removed ~1,180 lines of verified-dead and duplicated internal code from a whole-repo over-engineering audit. Includes dead native protocol constants and handshake helpers, an unused `AdbcErrorCode` enum, dead session/query helpers, and consolidation of the triplicated TLS certificate verifiers (into `transport::tls`) and the hand-rolled CSV parse/format/decompress paths.
+- Breaking: removed unused public API with no real consumers — `connection::session::SessionManager`, and the never-constructed `ExportError` variants `CsvParse`/`Arrow`/`Schema`/`Parquet` (plus the corresponding `From<parquet::errors::ParquetError>` impl). The documented public surface (`ArrowConverter`, `ResultSetIterator`, the `blocking_*` sync API, `ArrowToCsvWriter`, `CsvToArrowReader`) is unchanged.
+- Fix (tests): the test harness no longer mutates the shared process environment, so the integration suite is now order-independent regardless of thread count or execution order.
+
 ## 0.12.8
 
 - Feat: two new `Connection` methods for multi-row prepared-statement execution: `execute_batch_update` (executes a batch and returns the total affected row count) and `execute_batch` (executes a batch and returns a `ResultSet`). Both accept a slice of row parameter sets and handle column-major wire encoding internally.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.12.8"
+version = "0.13.0"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.12.8"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]

--- a/specs/code-quality/core/spec.md
+++ b/specs/code-quality/core/spec.md
@@ -36,6 +36,14 @@ The codebase SHALL maintain zero clippy warnings when built with all targets and
 * *THEN* integration tests against Exasol database MUST pass
 * *AND* driver functionality SHALL remain intact
 
+### Scenario: Tests do not mutate shared process environment
+
+* *GIVEN* the test suite under `tests/`
+* *WHEN* any test exercises environment-derived configuration (e.g. the `EXASOL_HOST`/`EXASOL_PORT`/`EXASOL_USER`/`EXASOL_PASSWORD` connection parameters)
+* *THEN* it SHALL NOT call `std::env::set_var` or `std::env::remove_var`
+* *AND* logic that depends on those values SHALL be exercised through pure helpers that take the values as arguments (e.g. `common::connection_string`)
+* *AND* the integration suite MUST produce identical results regardless of test execution order or `--test-threads` count
+
 ### Scenario: Arrow and Parquet dependencies resolve to version 58 or above with no duplicate sub-crate versions
 
 * *GIVEN* the resolved dependency tree in `Cargo.lock`

--- a/specs/decision-log.md
+++ b/specs/decision-log.md
@@ -226,3 +226,38 @@ Treat a URI-specified schema as a best-effort default. During `connect_with_tran
 ### Consequences
 
 dbt and similar tools can connect against a not-yet-existing default schema and create it afterwards; fully qualified relations continue to resolve, and the caller may activate the schema later via `set_schema()`. Non-missing failures (auth, permissions, transport) still close the transport and return a clear error, so no half-open connection is ever leaked. The missing-schema classification is message-based (substring "not found" on the lowercased error text), which is a known brittleness: if Exasol changes its "schema ... not found" wording, a missing schema could be misclassified as fatal (or vice versa). The behavior is guarded by unit tests `schema_open_error_missing_schema_is_recognized` and `schema_open_error_unrelated_is_fatal`, and by the ignored live integration test `test_connect_with_nonexistent_uri_schema_succeeds`.
+
+---
+
+## ADR-009: In a library, "unused internally" is not "dead" — and tests must not mutate global env
+
+**Date:** 2026-06-22
+**Plan:** `ponytail-audit-cleanup`
+**Status:** Accepted
+
+### Context
+
+A whole-repo over-engineering audit flagged ~3,500 lines as removable. Much of it was a category error: a *library* legitimately exports surface its own internals never call (it exists for downstream consumers), so "zero internal callers" alone does not make a symbol dead. Separately, the audit surfaced a long-standing test-isolation defect: non-`#[ignore]` unit tests in `tests/common/mod.rs` called `env::remove_var` on the `EXASOL_*` connection vars. Because that module compiles into every integration-test binary and the suite runs `--test-threads=1`, those tests wiped the configured connection parameters mid-run, so later tests silently fell back to `localhost:8563` and failed against any non-default container.
+
+### Decision
+
+Two rules, both from this cleanup:
+
+1. **Deletion criterion.** Only remove a symbol when it has zero non-test callers **and** is not part of the public API (not re-exported via `lib.rs` or any `pub use`, and not reachable through a `pub mod`). Documented or exported surface — `ArrowConverter`, `ResultSetIterator`, the `blocking_*` sync API, `ArrowToCsvWriter`, `CsvToArrowReader` — is retained even when internally unused; its removal is a deliberate, separately-decided breaking change. Genuinely-unreachable internals (e.g. `SessionManager`, dead protocol constants) are removed.
+
+2. **Tests never mutate the shared process environment.** No test calls `env::set_var`/`remove_var`. Env-derived logic is exercised through pure helpers taking explicit arguments (e.g. `common::connection_string`). See the code-quality scenario "Tests do not mutate shared process environment".
+
+Removing the unreachable public items (`connection::session::SessionManager`, the unused `ExportError` variants) is a breaking change, released as `0.13.0`.
+
+### Options Considered
+
+| Option | Verdict |
+|--------|---------|
+| Delete only verified-dead, non-exported code; retain public surface | ✓ Chosen — preserves the library's contract with downstreams while still removing genuine bloat |
+| Delete everything with zero internal callers | ✗ Rejected — strips legitimate public API that exists for consumers, not internal use |
+| Fix env-mutating tests via save/restore + a serial mutex | ✗ Rejected — still mutates global env (a window remains; `set_var` is `unsafe` in edition 2024); pure helpers eliminate the hazard entirely |
+| Patch-bump (0.12.9) despite removing public items | ✗ Rejected — removing reachable `pub` API is breaking under Cargo 0.x semver |
+
+### Consequences
+
+Future audits MUST apply the deletion criterion before removing any `pub` symbol. The test suite is now order-independent regardless of thread count or execution order, asserted by the new code-quality scenario. Separately, investigating the full `--include-ignored` run surfaced two pre-existing, `#[ignore]`-gated integration tests (never run by the CI integration stage, which omits `--include-ignored`) that were broken independently of this cleanup and were brought into line with the recorded behavior: `test_connect_with_nonexistent_uri_schema_succeeds` used `use_tls(false)` against the TLS-only container (fixed to accept the self-signed cert), and `test_uri_schema_activation_failure_returns_error` asserted the pre-ADR-007 fatal behavior — it was reconciled with ADR-007 and renamed `test_uri_schema_missing_is_best_effort_via_adbc`, asserting best-effort success on the ADBC URI path. Because `0.13.0` is breaking for downstreams pinned to `^0.12`, the release chain requires bumping `exapump`'s `exarrow-rs` constraint and advancing the `adbc-driver-exasol` vendored submodule pointer.

--- a/src/adbc/connection.rs
+++ b/src/adbc/connection.rs
@@ -2153,6 +2153,15 @@ impl ConnectionBuilder {
         self
     }
 
+    /// Enable or disable server-certificate validation.
+    ///
+    /// Disable when connecting to an Exasol Docker container, which ships a
+    /// self-signed certificate that would otherwise fail validation.
+    pub fn validate_server_certificate(mut self, validate: bool) -> Self {
+        self.params_builder = self.params_builder.validate_server_certificate(validate);
+        self
+    }
+
     /// Build and connect.
     ///
     /// # Returns

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -136,13 +136,14 @@ pub fn get_password() -> String {
 /// // Returns something like: "exasol://sys:exasol@localhost:8563?validate_certificate=false"
 /// ```
 pub fn get_test_connection_string() -> String {
-    format!(
-        "exasol://{}:{}@{}:{}?tls=true&validateservercertificate=0",
-        get_user(),
-        get_password(),
-        get_host(),
-        get_port()
-    )
+    connection_string(&get_user(), &get_password(), &get_host(), get_port())
+}
+
+/// Pure connection-string builder. Kept separate from the env-reading
+/// [`get_test_connection_string`] so it can be unit-tested with explicit
+/// arguments — tests must never mutate the shared process environment.
+pub fn connection_string(user: &str, password: &str, host: &str, port: u16) -> String {
+    format!("exasol://{user}:{password}@{host}:{port}?tls=true&validateservercertificate=0")
 }
 
 /// Build a connection string for a specific transport type.
@@ -358,40 +359,16 @@ mod tests {
         assert_eq!(DEFAULT_PASSWORD, "exasol");
     }
 
-    #[test]
-    fn test_get_host_default() {
-        // Clear env var if set
-        env::remove_var(ENV_EXASOL_HOST);
-        assert_eq!(get_host(), DEFAULT_HOST);
-    }
-
-    #[test]
-    fn test_get_port_default() {
-        env::remove_var(ENV_EXASOL_PORT);
-        assert_eq!(get_port(), DEFAULT_PORT);
-    }
-
-    #[test]
-    fn test_get_user_default() {
-        env::remove_var(ENV_EXASOL_USER);
-        assert_eq!(get_user(), DEFAULT_USER);
-    }
-
-    #[test]
-    fn test_get_password_default() {
-        env::remove_var(ENV_EXASOL_PASSWORD);
-        assert_eq!(get_password(), DEFAULT_PASSWORD);
-    }
+    // Note: the env-reading getters (get_host/get_port/get_user/get_password) are
+    // deliberately NOT unit-tested here. Doing so requires mutating the shared
+    // process environment (env::remove_var), which leaks into every other test in
+    // the binary and makes the integration suite order-dependent. The defaults are
+    // covered by `test_default_constants`; the DSN format is covered below via the
+    // pure `connection_string` builder.
 
     #[test]
     fn test_connection_string_format() {
-        // Clear all env vars to use defaults
-        env::remove_var(ENV_EXASOL_HOST);
-        env::remove_var(ENV_EXASOL_PORT);
-        env::remove_var(ENV_EXASOL_USER);
-        env::remove_var(ENV_EXASOL_PASSWORD);
-
-        let conn_str = get_test_connection_string();
+        let conn_str = connection_string("sys", "exasol", "localhost", 8563);
         assert_eq!(
             conn_str,
             "exasol://sys:exasol@localhost:8563?tls=true&validateservercertificate=0"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -472,7 +472,7 @@ async fn test_connect_with_nonexistent_uri_schema_succeeds() {
         .username(&get_user())
         .password(&common::get_password())
         .schema(&schema_name)
-        .use_tls(false)
+        .validate_server_certificate(false)
         .connect()
         .await;
 
@@ -2256,12 +2256,14 @@ async fn test_uri_schema_is_opened_on_connect() {
     close_result.expect("close should succeed");
 }
 
-/// Connecting with a URI that names a schema which does NOT exist must
-/// surface the failure as `Err(...)`, not return a half-open `Connection`
-/// whose session state silently disagrees with the URI.
+/// Connecting with a URI that names a schema which does NOT exist must SUCCEED:
+/// per ADR-007 the implicit `OPEN SCHEMA` "schema ... not found" failure is
+/// swallowed and the session stays open with no active schema. This exercises
+/// the ADBC URI path (the one dbt uses); the builder path is covered by
+/// `test_connect_with_nonexistent_uri_schema_succeeds`.
 #[tokio::test]
 #[ignore]
-async fn test_uri_schema_activation_failure_returns_error() {
+async fn test_uri_schema_missing_is_best_effort_via_adbc() {
     skip_if_no_exasol!();
 
     let driver = exarrow_rs::adbc::Driver::new();
@@ -2278,18 +2280,23 @@ async fn test_uri_schema_activation_failure_returns_error() {
         .open(&conn_str)
         .expect("URI parse with schema should succeed");
 
-    let result = database.connect().await;
+    let conn = database.connect().await;
 
     assert!(
-        result.is_err(),
-        "connect() with non-existent URI schema must return Err, got Ok(...)"
+        conn.is_ok(),
+        "connect() with a non-existent URI schema must succeed (best-effort default, ADR-007), got: {:?}",
+        conn.err()
     );
-    let error_msg = result.unwrap_err().to_string().to_lowercase();
-    assert!(
-        error_msg.contains("schema") || error_msg.contains(&bogus_schema.to_lowercase()),
-        "error should reference the schema activation failure, got: {}",
-        error_msg
+    let conn = conn.unwrap();
+
+    // The missing schema was swallowed, so no schema is active.
+    assert_eq!(
+        conn.current_schema().await,
+        None,
+        "a swallowed missing URI schema must leave the session with no active schema"
     );
+
+    conn.close().await.expect("close should succeed");
 }
 
 // Section 10: Placeholder scanning and IN-clause integration tests


### PR DESCRIPTION
## Why

PR #43 was squash-merged at the state of its **first** commit only (cleanup), so `main` still has `version = "0.12.8"` — the release job failed on the unbumped version. The second commit on that branch (version bump + test fixes + specs) never reached `main`. This PR carries exactly that missing delta on top of the merged cleanup.

## Contents (the delta missing from `main`)

**Version → `0.13.0`** (`Cargo.toml` + `Cargo.lock` + CHANGELOG). Minor (not patch) bump because the merged cleanup removed reachable public API — unused `ExportError` variants and `connection::session::SessionManager` — which is breaking under Cargo 0.x semver.

**Test env-isolation** — `tests/common/mod.rs` no longer mutates the shared process environment (extracted a pure `connection_string(...)`; removed the four `test_get_*_default` tests whose `env::remove_var` calls leaked into every integration-test binary). The integration suite is now order-independent.

**URI-schema test reconciliation (ADR-007)** — both `#[ignore]` (CI's integration stage omits `--include-ignored`):
- `test_connect_with_nonexistent_uri_schema_succeeds` used `use_tls(false)` against the TLS-only Docker container → now accepts the self-signed cert over TLS.
- `test_uri_schema_activation_failure_returns_error` asserted pre-ADR-007 fatal behavior → reconciled with ADR-007 and renamed `test_uri_schema_missing_is_best_effort_via_adbc`.

**API addition (additive)** — `Connection::builder().validate_server_certificate(bool)`, so the builder can reach a self-signed Exasol over TLS.

**Specs** — `code-quality/core` env-isolation scenario + `decision-log.md` ADR-009.

## Verification (live Exasol Docker 2025.2.1)
- unit **1011 ok**; integration `--include-ignored` **61 ok / 0 failed** in both single- and default-threaded runs (order-independent); import/export **42 ok**; driver-manager **37 ok**
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean under pinned **1.92.0**
- `Cargo.toml` version confirmed `0.13.0`

## After merge — release chain
0.13.0 is breaking for downstreams pinned to `^0.12`: bump `exapump`'s `exarrow-rs` constraint to `0.13` (+ release) and advance the `adbc-driver-exasol` vendored submodule pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)