### PR TITLE
ci: add SonarQube Cloud static analysis job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,51 @@ jobs:
       - name: Run unit tests with coverage
         run: cargo llvm-cov --lib --lcov --output-path lcov-unit.info
 
+      - name: Upload unit coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-unit
+          path: lcov-unit.info
+          if-no-files-found: error
+          retention-days: 1
+
+  sonar:
+    name: Sonar Analysis
+    needs: [unit-tests]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Shallow clones disabled for a better relevancy of analysis
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.92.0
+        with:
+          components: clippy, rustfmt
+
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Download unit coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: lcov-unit
+
+      - name: SonarQube Cloud scan
+        uses: SonarSource/sonarqube-scan-action@v8.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   integration-tests:
     name: Integration Tests
     needs: [lint, licenses, unit-tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
     name: Sonar Analysis
     needs: [unit-tests]
     runs-on: ubuntu-latest
+    # Fork PRs don't get repo secrets, so SONAR_TOKEN would be empty and fail the scan.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ tmp
 # Contains mutation testing data
 **/mutants.out*/
 
+# Coverage artifacts (cargo-llvm-cov)
+lcov-*.info
+*.profraw
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Driver manager tests (`tests/driver_manager_tests.rs`) load `target/release/libe
 - **GitHub Actions cache is immutable** — once a cache entry exists for a key based on `Cargo.lock`, it cannot be updated. The integration tests job explicitly rebuilds the release cdylib before driver manager tests to avoid stale artifacts.
 - **`cargo test` captures stdout/stderr by default.** When adding diagnostic `eprintln!` traces for CI debugging, use `--nocapture`. Always verify diagnostic output is visible before adding more instrumentation.
 - Integration tests job has `timeout-minutes: 30` to prevent runaway hangs.
+- **SonarQube Cloud static analysis** runs via the `Sonar Analysis` job (config in `sonar-project.properties`), consuming the `unit-tests` job's lcov output for coverage. Its Quality Gate is intended to become a required, PR-blocking check (alongside Build/Lint/License Check/Unit Tests/Integration Tests) once rolled out. Integration-test coverage is deliberately not fed into Sonar — same FFI/`cargo-llvm-cov` atexit-hang reason as the driver manager tests above.
 
 ## Debugging CI Hangs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ Driver manager tests (`tests/driver_manager_tests.rs`) load `target/release/libe
 - **GitHub Actions cache is immutable** — once a cache entry exists for a key based on `Cargo.lock`, it cannot be updated. The integration tests job explicitly rebuilds the release cdylib before driver manager tests to avoid stale artifacts.
 - **`cargo test` captures stdout/stderr by default.** When adding diagnostic traces for CI debugging, use `--nocapture`.
 - The integration tests job has a 30-minute timeout to prevent runaway hangs.
+- **SonarQube Cloud static analysis** runs via the `Sonar Analysis` job (config in `sonar-project.properties`), consuming the `unit-tests` job's lcov output for coverage. Its Quality Gate is intended to become a required, PR-blocking check (alongside Build/Lint/License Check/Unit Tests/Integration Tests) once rolled out. Integration-test coverage is deliberately not fed into Sonar — same FFI/`cargo-llvm-cov` atexit-hang reason as the driver manager tests above.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Documentation](https://docs.rs/exarrow-rs/badge.svg)](https://docs.rs/exarrow-rs)
 [![Rust](https://img.shields.io/badge/rust-stable-brightgreen.svg)](https://www.rust-lang.org/)
 [![CI](https://github.com/exasol-labs/exarrow-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/exasol-labs/exarrow-rs/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=exasol-labs_exarrow-rs&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=exasol-labs_exarrow-rs)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 ADBC-compatible driver for Exasol with Apache Arrow data format support.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+# SonarQube Cloud project binding
+sonar.projectKey=exasol-labs_exarrow-rs
+sonar.organization=exasol-labs
+
+# Source layout (benches/ and examples/ are intentionally not analyzed)
+sonar.sources=src
+sonar.tests=tests
+
+# Rust unit-test coverage (imported from the unit-tests job artifact)
+sonar.rust.lcov.reportPaths=lcov-unit.info
+
+# Fail the scan step (and thus the GitHub check) when the Quality Gate fails
+sonar.qualitygate.wait=true


### PR DESCRIPTION
## Summary

Adds a new `Sonar Analysis` CI job that runs SonarQube Cloud (formerly SonarCloud, still at sonarcloud.io) static analysis on every PR, using the existing `SONAR_TOKEN` org secret. Rust analysis runs via SonarCloud's built-in Clippy-backed analyzer; unit-test coverage (`lcov-unit.info`, already generated by the `unit-tests` job but previously unused) is now uploaded as an artifact and fed into the Sonar scan via `sonar.rust.lcov.reportPaths`.

- New job `sonar` (display name `Sonar Analysis`) — standalone, only depends on `unit-tests`, so it isn't gated behind the 30-minute `Integration Tests` Docker run.
- New `sonar-project.properties` — `sonar.organization=exasol-labs`, `sonar.projectKey=exasol-labs_exarrow-rs` (assumed `<org>_<repo>` convention — **please confirm this is the actual provisioned project key** if it differs), `sonar.sources=src`, `sonar.tests=tests`, `sonar.qualitygate.wait=true` so a failed Quality Gate fails the check.
- Integration-test coverage is deliberately excluded from the Sonar scan (same FFI/`cargo-llvm-cov` atexit-hang reason already documented for driver-manager tests).
- Docs updated (`AGENTS.md`, `CONTRIBUTING.md` CI Pipeline sections), README quality-gate badge added, `.gitignore` covers local `lcov-*.info`/`*.profraw`.

## Secret safety

- `SONAR_TOKEN` is scoped to a single step's `env:`, never echoed/logged.
- Trigger stays `pull_request` (not `pull_request_target`) — forked PRs get a read-only token and no repo secrets, so `SONAR_TOKEN` is never exposed to untrusted fork code.
- New job has an explicit `permissions: contents: read` block rather than relying on default token scope.

## Rollout — this PR is Phase 1 only

This PR only adds the CI job — it does **not** touch branch protection. Once this job is confirmed green here, a **separate, manual** follow-up will update the repository-level ruleset to make this job (and the existing Build/Lint/License Check/Unit Tests/Integration Tests jobs) required status checks. That is intentionally not bundled into this PR, so a misconfigured Sonar project/token can't lock every PR behind a check that never resolves.

## Test plan
- [ ] `unit-tests` job uploads the `lcov-unit` artifact successfully
- [ ] `Sonar Analysis` job downloads it and completes (pass, or a clear diagnosable failure if the project key needs correcting)
- [ ] SonarCloud PR decoration / analysis appears on sonarcloud.io for this PR
- [ ] Rest of existing CI (Build/Lint/License Check/Unit Tests/Integration Tests) still passes unaffected