### PR TITLE
fix: suppress secrets:S6706 false positive in websocket.rs tests

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,3 +11,11 @@ sonar.rust.lcov.reportPaths=lcov-unit.info
 
 # Fail the scan step (and thus the GitHub check) when the Quality Gate fails
 sonar.qualitygate.wait=true
+
+# websocket.rs unit tests embed synthetic RSA keypairs to round-trip the
+# password-encryption handshake. They are generated purely for the test,
+# never used for anything real, and cannot be "revoked" — suppress the
+# secret-detection false positive for this file only.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=secrets:S6706
+sonar.issue.ignore.multicriteria.e1.resourceKey=src/transport/websocket.rs


### PR DESCRIPTION
## Summary
- SonarCloud's BLOCKER finding (`secrets:S6706`, https://sonarcloud.io/project/issues?impactSeverities=BLOCKER&issueStatuses=OPEN&id=exasol-labs_exarrow-rs&open=AZ-pIbSwkCHlYUkD_fDJ) flags a "disclosed private key" at `src/transport/websocket.rs:1190`.
- That line is a synthetic 1024-bit RSA private key generated solely for `test_encrypt_password_with_1024_bit_key_decrypts_correctly`, already commented "Test-only ... Do not use in production." It never leaves the test and there is no real credential to revoke.
- Scoped a `sonar.issue.ignore.multicriteria` rule exclusion for `secrets:S6706` to this one file, rather than broadly disabling the secrets rule.

## Test plan
- [x] No code behavior changed — config-only fix.
- [ ] Confirm the Sonar Analysis CI job no longer reports this BLOCKER on the next run.