### PR TITLE
fix: export AdbcDriverExasolInit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.1
+
+- Fix: the ADBC driver now exports its init symbol as `AdbcDriverExasolInit`, matching the ADBC C API naming convention `AdbcDriver<Name>Init`. The previous symbol, `ExarrowDriverInit`, is kept as a backward-compatible alias.
+
 ## 0.14.0
 
 - Breaking: `ConnectionParams::query_timeout` is now `Option<Duration>` (was `Duration`, silently defaulting to 300s). A configured timeout is no longer enforced by a client-side timer; instead it is forwarded to Exasol as the server-enforced `queryTimeout` session attribute, and the server aborts an over-running query and reports it through the normal response cycle. The default is now no timeout attribute set at all — the server's own `QUERY_TIMEOUT` governs — instead of a silent client-side 300s/120s timer. `Statement::timeout_ms()` similarly changes return type from `u64` to `Option<u64>`, with `None` as the new default (was `120_000`). The client-side `tokio::time::timeout` wrap around query execution has been removed entirely: a client-side give-up on a running query used to abandon the in-flight request and desync the connection's single owned transport; the server now enforces and reports timeouts instead.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "exarrow-rs"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exarrow-rs"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 authors = ["Exasol Labs <labs@exasol.com>"]

--- a/specs/adbc-driver/driver-interface/spec.md
+++ b/specs/adbc-driver/driver-interface/spec.md
@@ -89,6 +89,13 @@ The system implements the ADBC (Arrow Database Connectivity) driver interface to
 * *AND* the driver SHALL extract the seconds fraction precision from the SECOND parameter
 * *AND* the driver SHALL NOT return an "Unknown Exasol type" error
 
+### Scenario: ADBC-compliant driver init symbol export
+
+* *GIVEN* an ADBC driver manager loads the driver's shared library
+* *WHEN* it resolves the library's init entrypoint
+* *THEN* the library SHALL export `AdbcDriverExasolInit` per the ADBC C API naming convention `AdbcDriver<Name>Init`
+* *AND* the library SHALL also export `ExarrowDriverInit` as a compatibility alias forwarding to `AdbcDriverExasolInit`
+
 ### Scenario: Boxed RecordBatchReader return type compliance
 
 * *GIVEN* the ADBC FFI driver is loaded by a driver manager

--- a/src/adbc_ffi.rs
+++ b/src/adbc_ffi.rs
@@ -2400,8 +2400,8 @@ pub unsafe extern "C" fn ExarrowDriverInit(
     driver: *mut std::os::raw::c_void,
     error: *mut adbc_ffi::FFI_AdbcError,
 ) -> adbc_core::error::AdbcStatusCode {
-    // AdbcDriverExasolInit is the "proper" name (note the lowercase) but
-    // initial versions exported ExarrowDriverInit instead.
+    // `AdbcDriverExasolInit` matches the ADBC-recommended entrypoint naming convention.
+    // Initial versions exported `ExarrowDriverInit` instead.
     AdbcDriverExasolInit(version, driver, error)
 }
 

--- a/src/adbc_ffi.rs
+++ b/src/adbc_ffi.rs
@@ -2385,8 +2385,21 @@ impl adbc_core::Statement for FfiStatement {
 // -----------------------------------------------------------------------------
 
 // Export the driver using the adbc_ffi macro.
-// The exported function will be named `ExarrowDriverInit`.
-adbc_ffi::export_driver!(ExarrowDriverInit, FfiDriver);
+// The exported function will be named `AdbcDriverExasolInit`.
+adbc_ffi::export_driver!(AdbcDriverExasolInit, FfiDriver);
+
+#[allow(non_snake_case)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ExarrowDriverInit(
+    version: std::os::raw::c_int,
+    driver: *mut std::os::raw::c_void,
+    error: *mut adbc_ffi::FFI_AdbcError,
+) -> adbc_core::error::AdbcStatusCode {
+    // Compatibility alias. AdbcDriverExasolInit is the "proper" name
+    // (note the lowercase) but initial versions exported ExarrowDriverInit
+    // instead.
+    AdbcDriverExasolInit(version, driver, error)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/adbc_ffi.rs
+++ b/src/adbc_ffi.rs
@@ -2388,6 +2388,11 @@ impl adbc_core::Statement for FfiStatement {
 // The exported function will be named `AdbcDriverExasolInit`.
 adbc_ffi::export_driver!(AdbcDriverExasolInit, FfiDriver);
 
+/// Compatibility alias.
+///
+/// # Safety
+///
+/// `driver` must not be NULL. `error` may be NULL.
 #[allow(non_snake_case)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ExarrowDriverInit(
@@ -2395,9 +2400,8 @@ pub unsafe extern "C" fn ExarrowDriverInit(
     driver: *mut std::os::raw::c_void,
     error: *mut adbc_ffi::FFI_AdbcError,
 ) -> adbc_core::error::AdbcStatusCode {
-    // Compatibility alias. AdbcDriverExasolInit is the "proper" name
-    // (note the lowercase) but initial versions exported ExarrowDriverInit
-    // instead.
+    // AdbcDriverExasolInit is the "proper" name (note the lowercase) but
+    // initial versions exported ExarrowDriverInit instead.
     AdbcDriverExasolInit(version, driver, error)
 }
 


### PR DESCRIPTION
Assuming the binary is libadbc_driver_exasol.so, the proper name for the init symbol is AdbcDriverExasolInit and not ExarrowDriverInit. But export both symbols for compatibility.

https://github.com/apache/arrow-adbc/blob/ca0aa5e4c49d5ea2853792a8045e3310d92c3606/c/include/arrow-adbc/adbc.h#L2383-L2392