### PR TITLE
docs: document the automated release process and [Unreleased] changelog convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,8 @@ When a CI test hangs:
 
 ## Changelog
 
-- `CHANGELOG.md` must be updated with every version bump
-- Format: `## <version>` header followed by bullet points describing changes
-- Entries should be concise, user-facing descriptions (not internal implementation details)
+- `CHANGELOG.md` must be updated in the same PR as any user-facing change.
+- PR without a version bump → add entries under a `## [Unreleased]` header. Merging it does not release.
+- PR that bumps the `Cargo.toml` version → put entries under a `## X.Y.Z` header matching the version exactly (fold in `[Unreleased]`). Merging it makes the CI `release` job tag, release, and publish to crates.io automatically.
+- Entries should be concise, user-facing descriptions (not internal implementation details).
+- Full release procedure: see `CONTRIBUTING.md` § Releasing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,25 @@ Driver manager tests (`tests/driver_manager_tests.rs`) load `target/release/libe
 
 ## Changelog
 
-- `CHANGELOG.md` must be updated with every version bump.
-- Format: `## <version>` header followed by bullet points describing changes.
-- Entries should be concise and user-facing — avoid internal implementation details.
+`CHANGELOG.md` must be updated in the same PR as any user-facing change. A PR falls into one of two cases:
+
+- **No version bump (the common case).** Add entries under a `## [Unreleased]` header at the top of the file, creating it if it does not exist. Merging such a PR does not release anything.
+- **Version bump (cuts a release).** The PR bumps the version in `Cargo.toml`, so merging it releases (see [Releasing](#releasing)). Put the entries under a `## X.Y.Z` header whose version matches `Cargo.toml` **exactly**, folding in anything currently under `## [Unreleased]`.
+
+Entries should be concise and user-facing — avoid internal implementation details.
+
+## Releasing
+
+Releasing is automated by the `release` job in `.github/workflows/ci.yml`, which runs on every push to `main` (that is, every merge). It reads the version from `Cargo.toml` and, **only if no `vX.Y.Z` git tag exists for that version yet**:
+
+1. creates and pushes the `vX.Y.Z` tag,
+2. creates a GitHub release whose notes are the `## X.Y.Z` section extracted from `CHANGELOG.md`,
+3. publishes the crate to crates.io.
+
+So a release is triggered by **merging a version bump to `main`** — nothing else. Merging a PR that leaves the `Cargo.toml` version unchanged never releases, because the tag already exists and the job no-ops.
+
+To cut a release, in a single PR:
+
+1. Bump `version` in `Cargo.toml` following [SemVer](https://semver.org), then run a build so `Cargo.lock` picks up the new version.
+2. In `CHANGELOG.md`, rename the `## [Unreleased]` header to `## X.Y.Z`, matching `Cargo.toml` exactly. The release job extracts the notes by an exact `## X.Y.Z` header match, so a mismatched version or a leftover `[Unreleased]` header produces empty release notes.
+3. Merge to `main`. CI tags, publishes the GitHub release, and publishes to crates.io automatically.


### PR DESCRIPTION
## Summary

Documents the **automated** release process and adopts the [Keep a Changelog](https://keepachangelog.com) `[Unreleased]` convention, so changes can accumulate on `main` without cutting a release.

Two gaps motivated this:
- **The release procedure was undocumented.** Releasing is driven by the `release` job in `.github/workflows/ci.yml` (runs on every push to `main`): it reads the version from `Cargo.toml` and, if no matching `vX.Y.Z` tag exists yet, tags the commit, creates a GitHub release from the `## X.Y.Z` changelog section, and publishes to crates.io. None of that was written down.
- **The changelog rule ("update with every version bump") did not describe how to stage changes that should not release**, pushing contributors toward always assigning a version.

## Changes

- `CONTRIBUTING.md` (source of truth):
  - `## Changelog` now describes the two cases — a PR **without** a version bump stages entries under `## [Unreleased]`; a PR **that bumps** `Cargo.toml` cuts a release and must use a `## X.Y.Z` header matching the version exactly.
  - New `## Releasing` section documenting the CI `release` job and the steps to cut a release (bump version, rename `[Unreleased]` → `X.Y.Z`, merge — CI does the tag/release/publish).
- `AGENTS.md`: short two-case rule plus a pointer to `CONTRIBUTING.md` § Releasing, to keep the docs from drifting. `CLAUDE.md` imports `AGENTS.md`, so it is covered automatically.

## Notes

Docs-only; no code changes. Corrects an earlier draft of this PR that wrongly described releasing as manual. Follows from review of #61, which should adopt this convention (record under `[Unreleased]`, drop its version bump) unless that PR is itself intended to cut the 0.17.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)