### PR TITLE
fix(ci): make the release job's crates.io check reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,10 @@ jobs:
     needs: [integration-tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Serialize releases; never cancel one mid-publish.
+    concurrency:
+      group: release
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -301,7 +305,7 @@ jobs:
       - name: Check if tag already exists
         id: check
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          if git rev-parse --verify --quiet "refs/tags/v${{ steps.version.outputs.version }}" >/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -340,14 +344,22 @@ jobs:
         id: crate
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if curl -sf "https://crates.io/api/v1/crates/exarrow-rs/$VERSION" | grep -q '"num"'; then
+          # Use the sparse index, not the API: it is built for automated
+          # clients. (The API also 403s curl's default User-Agent.)
+          # Fail on an unknown status; never guess.
+          STATUS=$(curl -s -o index.json -w '%{http_code}' "https://index.crates.io/ex/ar/exarrow-rs")
+          if [ "$STATUS" = "200" ] && grep -q "\"vers\":\"$VERSION\"" index.json; then
             echo "published=true" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "$STATUS" = "200" ] || [ "$STATUS" = "404" ]; then
+            # 404 = crate never published.
             echo "published=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected crates.io index status $STATUS" >&2
+            exit 1
           fi
 
       - name: Publish to crates.io
         if: steps.crate.outputs.published == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
-        run: cargo publish
+        run: cargo publish --locked


### PR DESCRIPTION
## Summary

The `release` job in `.github/workflows/ci.yml` **fails on every merge to `main` that does not bump the version** — most recently the #63 docs merge ([run](https://github.com/exasol-labs/exarrow-rs/actions/runs/31361709281/job/93373617937)), and repeatedly for ~2 months (it also failed on `0.12.8` on 2026-06-22 and again 2026-07-28). Version-bump merges pass, so releases themselves are not broken — but `main` shows a red CI run after every non-release merge, and #61 would hit the same failure on merge.

## Root cause

The failing step is **Publish to crates.io**:
```
error: crate exarrow-rs@0.16.0 already exists on crates.io index
```

The tag-existence gate works correctly (the tag/GitHub-release steps skip when `vX.Y.Z` already exists). The bug is in the crates.io *check*:

```bash
curl -sf "https://crates.io/api/v1/crates/exarrow-rs/$VERSION" | grep -q '"num"'
```

crates.io's API returns **HTTP 403 for requests with a non-descriptive `User-Agent`** (its [data-access policy](https://crates.io/data-access)) — curl's default `curl/8.x` UA is rejected. So `curl -sf` fails, `grep` sees empty input, and the step falls into `else` → `published=false`. `cargo publish` then runs for an already-published version and exits 101.

Verified with live requests: default curl UA → 403; the sparse index → 200.

## Fix

- **Query the sparse index instead of the API.** `https://index.crates.io/ex/ar/exarrow-rs` is CDN-served for automated clients (it is what cargo itself reads) and is not subject to the API data-access policy. Handle the HTTP status explicitly and **fail loudly** on anything unexpected instead of assuming "not published" — that wrong assumption is exactly what caused the bad publish.
- **Serialize releases** with a `concurrency: { group: release, cancel-in-progress: false }` so two quick merges cannot both tag/publish the same version.
- **Harden the tag check** to `git rev-parse --verify --quiet refs/tags/v$VERSION` (matches tags specifically rather than any ref/object).
- **`cargo publish --locked`** to pin the lockfile at publish time.

The tag/publish gating structure is intentionally left unchanged: tag steps keyed on tag state, publish keyed on crates.io state — independent signals for independent actions, which preserves self-healing if a publish fails after the tag is created.

## Notes

- The `"vers":"$VERSION"` grep matches the sparse-index line format (confirmed: `"vers":"0.16.0"` is present for this crate).
- CI-only change. This fix should also unblock #61's merge from failing the release job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)